### PR TITLE
Enhance recovery logic (see description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,44 @@ func main() {
 		panic(err)
 	}
 }
+```
 
+## Recovery
 
+Flowstate guarantees that if a flow is committed, it will eventually complete either successfully on retry or forcefully when the maximum retry limit is reached. 
+
+The recovery system automatically retries states that haven't reached a terminal state (ended or paused) within the configured time frame. 
+By default, recovery checks for stalled states after 2 minutes, but this can be adjusted using `recovery.SetRetryAfter()`. 
+The system performs up to 3 retry attempts by default before forcefully ending the state, configurable via `recovery.SetMaxAttempts()`.
+
+Recovery timing is approximate (equal or greater than retry after) and depends on system load and available resources. 
+The retry logic applies to all states by default unless explicitly disabled with `recovery.Disable()`.
+
+In cluster mode, one process remains active to handle all recovery operations while others stay in standby mode, ready to take over if needed.
+
+Example:
+```golang
+l := slog.New(slog.NewTextHandler(os.Stderr, nil))
+d := memdriver.New()
+
+e, err := flowstate.NewEngine(d, l)
+if err != nil {
+    log.Fatalf("failed to create engine: %v", err)
+}
+
+r := recovery.New(e, l)
+if err := r.Init(); err != nil {
+    log.Fatalf("failed to init recoverer: %v", err)
+}
+
+// do stuff with the engine
+
+if err := r.Shutdown(context.Background()); err != nil {
+    log.Fatalf("failed to shutdown recoverer: %v", err)
+}
+if err := e.Shutdown(context.Background()); err != nil {
+    log.Fatalf("failed to shutdown engine: %v", err)
+}
 ```
 
 ## Examples

--- a/recovery/helpers.go
+++ b/recovery/helpers.go
@@ -1,0 +1,86 @@
+package recovery
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/makasim/flowstate"
+)
+
+var EnabledAnnotation = `flowstate.recovery.enabled`
+
+func Disable(stateCtx *flowstate.StateCtx) {
+	stateCtx.Current.SetAnnotation(EnabledAnnotation, "false")
+}
+
+func enabled(state flowstate.State) bool {
+	return state.Annotations[EnabledAnnotation] != "false"
+}
+
+var AttemptAnnotation = `flowstate.recovery.attempt`
+
+func Attempt(state flowstate.State) int {
+	attempt, _ := strconv.Atoi(state.Transition.Annotations[AttemptAnnotation])
+	return attempt
+}
+
+func setAttempt(stateCtx *flowstate.StateCtx, attempt int) {
+	stateCtx.Current.Transition.SetAnnotation(AttemptAnnotation, strconv.Itoa(attempt))
+}
+
+var DefaultMaxAttempts = 3
+var MaxAttemptsAnnotation = `flowstate.recovery.max_attempts`
+
+func MaxAttempts(state flowstate.State) int {
+	attempt, _ := strconv.Atoi(state.Annotations[MaxAttemptsAnnotation])
+	if attempt <= 0 {
+		return DefaultMaxAttempts
+	}
+
+	return attempt
+}
+
+func SetMaxAttempts(stateCtx *flowstate.StateCtx, attempts int) {
+	if attempts <= 0 {
+		attempts = DefaultMaxAttempts
+	}
+
+	stateCtx.Current.SetAnnotation(MaxAttemptsAnnotation, strconv.Itoa(attempts))
+}
+
+var DefaultRetryAfter = time.Minute * 2
+var MinRetryAfter = time.Minute
+var MaxRetryAfter = time.Minute * 5
+var RetryAfterAnnotation = `flowstate.recovery.retry_after`
+
+func SetRetryAfter(stateCtx *flowstate.StateCtx, retryAfter time.Duration) {
+	if retryAfter < MinRetryAfter {
+		retryAfter = MinRetryAfter
+	}
+	if retryAfter > MaxRetryAfter {
+		retryAfter = MaxRetryAfter
+	}
+
+	stateCtx.Current.SetAnnotation(RetryAfterAnnotation, retryAfter.String())
+}
+
+func retryAt(state flowstate.State) time.Time {
+	retryAfterStr := state.Annotations[RetryAfterAnnotation]
+	if retryAfterStr == "" {
+		retryAfterStr = DefaultRetryAfter.String()
+	}
+
+	retryAfter, err := time.ParseDuration(retryAfterStr)
+	if err != nil {
+		return state.CommittedAt().Add(MinRetryAfter)
+	}
+
+	if retryAfter < MinRetryAfter {
+		retryAfter = MinRetryAfter
+	}
+	if retryAfter > MaxRetryAfter {
+		retryAfter = MaxRetryAfter
+	}
+
+	return state.CommittedAt().Add(retryAfter)
+}

--- a/recovery/recoverer.go
+++ b/recovery/recoverer.go
@@ -1,0 +1,439 @@
+package recovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/makasim/flowstate"
+)
+
+var stateID = flowstate.StateID(`flowstate.recovery.state`)
+
+type Recoverer struct {
+	mux sync.Mutex
+
+	recoveryStateCtx *flowstate.StateCtx
+
+	active   bool
+	sinceRev int64
+	headRev  int64
+	headTime time.Time
+	tailRev  int64
+	tailTime time.Time
+
+	states               map[flowstate.StateID]retryableState
+	statesMaxSize        int
+	statesMaxTailHeadDur time.Duration
+
+	added     int64
+	completed int64
+	retried   int64
+	dropped   int64
+	commited  int64
+
+	e         flowstate.Engine
+	doneCh    chan struct{}
+	stoppedCh chan struct{}
+	l         *slog.Logger
+}
+
+func New(e flowstate.Engine, l *slog.Logger) *Recoverer {
+	return &Recoverer{
+		e: e,
+		l: l,
+
+		statesMaxSize:        100000,
+		statesMaxTailHeadDur: MaxRetryAfter * 2,
+
+		doneCh:    make(chan struct{}),
+		stoppedCh: make(chan struct{}),
+	}
+}
+
+func (r *Recoverer) Init() error {
+	recoverStateCtx := &flowstate.StateCtx{}
+	active := true
+	if err := r.e.Do(flowstate.GetByID(recoverStateCtx, stateID, 0)); errors.Is(err, flowstate.ErrNotFound) {
+		recoverStateCtx = &flowstate.StateCtx{
+			Current: flowstate.State{
+				ID:  stateID,
+				Rev: 0,
+			},
+		}
+		Disable(recoverStateCtx)
+		setSinceRev(recoverStateCtx, 0)
+
+		if err := r.e.Do(flowstate.Commit(
+			flowstate.Transit(recoverStateCtx, `na`),
+		)); flowstate.IsErrRevMismatch(err) {
+			// another process is already doing recovery, we can continue in standby mode
+			active = false
+		} else if err != nil {
+			return fmt.Errorf("commit recovery state: %w", err)
+		}
+		r.commited++
+	} else if err != nil {
+		return fmt.Errorf("get recovery state: %w", err)
+	} else {
+		active = flowstate.Paused(recoverStateCtx.Current)
+	}
+
+	r.reset(recoverStateCtx, active)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.updateHead()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.updateTail()
+	}()
+	go func() {
+		wg.Wait()
+		close(r.stoppedCh)
+	}()
+
+	return nil
+}
+
+func (r *Recoverer) Shutdown(ctx context.Context) error {
+	close(r.doneCh)
+
+	select {
+	case <-r.stoppedCh:
+		setSinceRev(r.recoveryStateCtx, r.nextSinceRev())
+		if err := r.e.Do(flowstate.Commit(flowstate.Pause(r.recoveryStateCtx))); flowstate.IsErrRevMismatch(err) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("commit: pause recovery state: %w", err)
+		}
+
+		r.reset(r.recoveryStateCtx, false)
+
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type Stats struct {
+	HeadRev  int64
+	HeadTime time.Time
+	TailRev  int64
+	TailTime time.Time
+
+	Commited  int64
+	Added     int64
+	Completed int64
+	Retried   int64
+	Dropped   int64
+
+	Active bool
+}
+
+func (r *Recoverer) Stats() Stats {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	return Stats{
+		HeadRev:  r.headRev,
+		HeadTime: r.headTime,
+		TailRev:  r.tailRev,
+		TailTime: r.tailTime,
+
+		Added:     r.added,
+		Completed: r.completed,
+		Retried:   r.retried,
+		Dropped:   r.dropped,
+		Commited:  r.commited,
+
+		Active: r.active,
+	}
+}
+
+func (r *Recoverer) updateHead() {
+	t := time.NewTicker(time.Second * 10)
+	defer t.Stop()
+
+	prevAt := time.Now()
+	var dur time.Duration
+	for {
+		if err := r.doUpdateHead(dur); err != nil {
+			r.l.Error(fmt.Sprintf("update head: %s; retrying", err))
+			continue
+		}
+
+		select {
+		case <-r.doneCh:
+			return
+		case at := <-t.C:
+			dur = at.Sub(prevAt)
+			prevAt = at
+		}
+	}
+}
+
+func (r *Recoverer) doUpdateHead(dur time.Duration) error {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	first := true
+	for {
+		// TODO: breaks ticks logic
+		//if len(r.states) > r.statesMaxSize {
+		//	r.headTime = r.headTime.Add(dur)
+		//	return nil
+		//}
+		//if len(r.states) > 0 && r.tailTime.Add(r.statesMaxTailHeadDur).Before(r.headTime) {
+		//	r.headTime = r.headTime.Add(dur)
+		//	return nil
+		//}
+
+		getManyCmd := flowstate.GetManyByLabels(nil).WithSinceRev(r.sinceRev)
+		if err := r.e.Do(getManyCmd); err != nil {
+			return fmt.Errorf("get many states: %w; since_rev=%d", err, r.sinceRev)
+		}
+		res, err := getManyCmd.Result()
+		if err != nil {
+			return fmt.Errorf("get many states: result: %w", err)
+		}
+
+		completed, added := r.completed, r.added
+		for _, state := range res.States {
+			r.sinceRev = state.Rev
+
+			if state.ID == stateID {
+				r.recoveryStateCtx = state.CopyToCtx(r.recoveryStateCtx)
+				if state.Rev > r.recoveryStateCtx.Committed.Rev {
+					active := flowstate.Paused(state)
+					r.reset(r.recoveryStateCtx, active)
+				}
+				continue
+			}
+
+			if !enabled(state) {
+				continue
+			}
+
+			r.headRev = state.Rev
+			r.headTime = state.CommittedAt()
+			if len(r.states) == 0 {
+				r.tailRev = r.headRev
+				r.tailTime = r.headTime
+			}
+
+			if !r.active {
+				continue
+			}
+			if flowstate.Ended(state) || flowstate.Paused(state) {
+				delete(r.states, state.ID)
+				r.completed++
+
+				continue
+			}
+
+			r.states[state.ID] = retryableState{
+				State:   state.CopyTo(&flowstate.State{}),
+				retryAt: retryAt(state),
+			}
+			r.added++
+		}
+
+		if first && r.completed == completed && r.added == added {
+			r.headTime = r.headTime.Add(dur)
+			if len(r.states) == 0 {
+				r.tailRev = r.headRev
+				r.tailTime = r.headTime
+			}
+
+			if len(res.States) == 0 {
+				return nil
+			}
+		}
+
+		first = false
+
+		if res.More {
+			r.mux.Unlock()
+			r.mux.Lock()
+			continue
+		}
+
+		return nil
+	}
+}
+
+func (r *Recoverer) updateTail() {
+	t := time.NewTicker(time.Second * 10)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-r.doneCh:
+			return
+		case <-t.C:
+			if err := r.doUpdateTail(); err != nil {
+				r.l.Error(fmt.Sprintf("update tail: %s; retrying", err))
+				continue
+			}
+		}
+	}
+}
+
+func (r *Recoverer) doUpdateTail() error {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	if !r.active {
+		commitedAt := r.recoveryStateCtx.Committed.CommittedAt()
+		if (commitedAt.Add(MaxRetryAfter+time.Minute).Before(time.Now()) && r.nextSinceRev() > getSinceRev(r.recoveryStateCtx)) ||
+			flowstate.Paused(r.recoveryStateCtx.Current) {
+			nextRecoveryStateCtx := r.recoveryStateCtx.CopyTo(&flowstate.StateCtx{})
+			if err := r.e.Do(flowstate.Commit(flowstate.Resume(r.recoveryStateCtx))); flowstate.IsErrRevMismatch(err) {
+				r.reset(r.recoveryStateCtx, false)
+				return nil
+			} else if err != nil {
+				return fmt.Errorf("commit recovery state: %w", err)
+			}
+			r.commited++
+			r.recoveryStateCtx = nextRecoveryStateCtx.CopyTo(r.recoveryStateCtx)
+
+			r.reset(r.recoveryStateCtx, true)
+		}
+
+		return nil
+	}
+
+	now := time.Now()
+
+	if err := r.doRetry(); err != nil {
+		return fmt.Errorf("do retry: %w", err)
+	}
+
+	tailRev := r.headRev
+	var tailTime time.Time
+	for _, retState := range r.states {
+		if retState.Rev < tailRev {
+			tailRev = retState.Rev
+			tailTime = retState.CommittedAt()
+		}
+	}
+	r.tailRev = tailRev
+	r.tailTime = tailTime
+
+	commitedAt := r.recoveryStateCtx.Committed.CommittedAt()
+	if r.tailRev > getSinceRev(r.recoveryStateCtx)+1000 ||
+		(commitedAt.Add(MaxRetryAfter).Before(now) && r.nextSinceRev() > getSinceRev(r.recoveryStateCtx)) {
+		nextStateCtx := r.recoveryStateCtx.CopyTo(&flowstate.StateCtx{})
+
+		setSinceRev(nextStateCtx, r.nextSinceRev())
+		if err := r.e.Do(flowstate.Commit(flowstate.Resume(nextStateCtx))); flowstate.IsErrRevMismatch(err) {
+			r.reset(r.recoveryStateCtx, false)
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("commit recovery state: %w", err)
+		}
+
+		r.commited++
+		r.recoveryStateCtx = nextStateCtx.CopyTo(r.recoveryStateCtx)
+	}
+
+	return nil
+}
+
+func (r *Recoverer) doRetry() error {
+	if len(r.states) == 0 {
+		return nil
+	}
+
+	states := make([]flowstate.State, 0)
+
+	for id, retState := range r.states {
+		if retState.retryAt.After(r.headTime) {
+			continue
+		}
+
+		states = append(states, retState.State.CopyTo(&flowstate.State{}))
+		delete(r.states, id)
+	}
+
+	for _, state := range states {
+		maxAttempts := MaxAttempts(state)
+		attempt := Attempt(state) + 1
+		stateCtx := state.CopyToCtx(&flowstate.StateCtx{})
+
+		setAttempt(stateCtx, attempt)
+		if attempt > maxAttempts {
+			if err := r.e.Do(flowstate.Commit(flowstate.End(stateCtx))); flowstate.IsErrRevMismatch(err) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("commit state %s:%d reached max retry attempts %d and forcfully ended: %s", state.ID, state.Rev, maxAttempts, err)
+			}
+
+			r.dropped++
+			continue
+		}
+
+		if err := r.e.Do(
+			flowstate.Commit(flowstate.CommitStateCtx(stateCtx)),
+			flowstate.Execute(stateCtx),
+		); flowstate.IsErrRevMismatch(err) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("commit state %s:%d recovery attempt %d: %s", state.ID, state.Rev, attempt, err)
+		}
+
+		r.retried++
+	}
+
+	return nil
+}
+
+func (r *Recoverer) reset(recoveryStateCtx *flowstate.StateCtx, active bool) {
+	r.active = active
+	r.recoveryStateCtx = recoveryStateCtx.CopyTo(&flowstate.StateCtx{})
+
+	r.sinceRev = getSinceRev(r.recoveryStateCtx)
+	r.headRev = r.sinceRev
+	r.headTime = time.Time{}
+	r.tailRev = r.headRev
+	r.tailTime = time.Time{}
+
+	r.states = make(map[flowstate.StateID]retryableState)
+}
+
+func (r *Recoverer) nextSinceRev() int64 {
+	if r.tailRev == 0 {
+		return 0
+	}
+
+	return r.tailRev - 1
+}
+
+func getSinceRev(stateCtx *flowstate.StateCtx) int64 {
+	sinceRevStr := stateCtx.Current.Annotations[`flowstate.recovery.since_rev`]
+	if sinceRevStr == "" {
+		return 0
+	}
+
+	sinceRev, _ := strconv.ParseInt(sinceRevStr, 10, 64)
+	return sinceRev
+}
+
+func setSinceRev(stateCtx *flowstate.StateCtx, sinceRev int64) {
+	stateCtx.Current.SetAnnotation(`flowstate.recovery.since_rev`, strconv.FormatInt(sinceRev, 10))
+}
+
+type retryableState struct {
+	flowstate.State
+	retryAt time.Time
+}

--- a/recovery/recovery_test.go
+++ b/recovery/recovery_test.go
@@ -1,0 +1,745 @@
+package recovery_test
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/makasim/flowstate"
+	"github.com/makasim/flowstate/memdriver"
+	"github.com/makasim/flowstate/recovery"
+	"github.com/thejerf/slogassert"
+)
+
+func TestRecovererRetryLogic(t *testing.T) {
+	f := func(genFn func(e flowstate.Engine), flowFn flowstate.FlowFunc, expStats recovery.Stats) {
+		t.Helper()
+
+		synctest.Run(func() {
+			lh := slogassert.New(t, slog.LevelDebug, nil)
+			l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
+
+			d := memdriver.New()
+			d.SetFlow(`aFlow`, flowFn)
+
+			e, err := flowstate.NewEngine(d, l)
+			if err != nil {
+				t.Fatalf("failed to create engine: %v", err)
+			}
+
+			r := recovery.New(e, l)
+			if err := r.Init(); err != nil {
+				t.Fatalf("failed to init recoverer: %v", err)
+			}
+
+			go genFn(e)
+			synctest.Wait()
+
+			time.Sleep(time.Hour)
+			synctest.Wait()
+
+			if err := r.Shutdown(context.Background()); err != nil {
+				t.Fatalf("failed to shutdown recoverer: %v", err)
+			}
+			if err := e.Shutdown(context.Background()); err != nil {
+				t.Fatalf("failed to shutdown engine: %v", err)
+			}
+			time.Sleep(time.Minute)
+			synctest.Wait()
+
+			actStats := r.Stats()
+			if expStats.Added != actStats.Added {
+				t.Errorf("expected added equal to %d; got %d", expStats.Added, actStats.Added)
+			}
+			if expStats.Completed != actStats.Completed {
+				t.Errorf("expected completed equal to %d; got %d", expStats.Completed, actStats.Completed)
+			}
+			if expStats.Retried != actStats.Retried {
+				t.Errorf("expected retried equal to %d; got %d", expStats.Retried, actStats.Retried)
+			}
+			if expStats.Dropped != actStats.Dropped {
+				t.Errorf("expected dropped equal to %d; got %d", expStats.Dropped, actStats.Dropped)
+			}
+			if expStats.Commited != actStats.Commited {
+				t.Errorf("expected commited equal to %d; got %d", expStats.Commited, actStats.Commited)
+			}
+		})
+	}
+
+	// recoverer should commit recoveryStateCtx only once if there is no state commits.
+	f(
+		func(e flowstate.Engine) {},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			t.Fatalf("unexpected call to flow function")
+			return nil, nil
+		},
+		recovery.Stats{
+			Commited: 1,
+		},
+	)
+
+	// states with disabled recovery ignored completely
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 100; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+					recovery.Disable(stateCtx)
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+					if err := e.Execute(stateCtx); err != nil {
+						t.Fatalf("failed to execute state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Commited: 1,
+		},
+	)
+
+	// states paused marked completed
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 100; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.End(stateCtx))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			t.Fatalf("unexpected call to flow function")
+			return nil, nil
+		},
+		recovery.Stats{
+			Completed: 100,
+			Commited:  2,
+		},
+	)
+
+	// states ended marked completed
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 100; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Pause(stateCtx))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			t.Fatalf("unexpected call to flow function")
+			return nil, nil
+		},
+		recovery.Stats{
+			Completed: 100,
+			Commited:  2,
+		},
+	)
+
+	// a state retried if there is no any further commits (aka test ticks work)
+	f(
+		func(e flowstate.Engine) {
+			stateCtx := &flowstate.StateCtx{
+				Current: flowstate.State{
+					ID: flowstate.StateID("aTID"),
+				},
+			}
+
+			if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+				t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+			}
+
+			// just commit, do not execute, recovery should kick in
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     2,
+			Completed: 1,
+			Retried:   1,
+			Commited:  2,
+		},
+	)
+
+	// every fifth state retried should be retried
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 100; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					if i%5 != 0 {
+						if err := e.Execute(stateCtx); err != nil {
+							t.Fatalf("failed to execute state %s: %v", stateCtx.Current.ID, err)
+						}
+						return
+					}
+					// just commit, do not execute, recovery should kick in
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     120,
+			Completed: 100,
+			Retried:   20,
+			Commited:  2,
+		},
+	)
+
+	// a state retried default max times (3)
+	f(
+		func(e flowstate.Engine) {
+			stateCtx := &flowstate.StateCtx{
+				Current: flowstate.State{
+					ID: flowstate.StateID("aTID"),
+				},
+			}
+
+			if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+				t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+			}
+
+			// just commit, do not execute, recovery should kick in
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			// do nothing to see how many times the state will be retried
+			return flowstate.Noop(stateCtx), nil
+		},
+		recovery.Stats{
+			Added:     4,
+			Completed: 1,
+			Retried:   3,
+			Dropped:   1,
+			Commited:  3,
+		},
+	)
+
+	// a state retried custom set max times (4)
+	f(
+		func(e flowstate.Engine) {
+			stateCtx := &flowstate.StateCtx{
+				Current: flowstate.State{
+					ID: flowstate.StateID("aTID"),
+				},
+			}
+			recovery.SetMaxAttempts(stateCtx, 4)
+
+			if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+				t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+			}
+
+			// just commit, do not execute, recovery should kick in
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			// do nothing to see how many times the state will be retried
+			return flowstate.Noop(stateCtx), nil
+		},
+		recovery.Stats{
+			Added:     5,
+			Completed: 1,
+			Retried:   4,
+			Dropped:   1,
+			Commited:  4,
+		},
+	)
+
+	// a state retried if there are new commits
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 30; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					// just commit, do not execute, recovery should kick in
+				}()
+
+				time.Sleep(time.Second * 30)
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     60,
+			Completed: 30,
+			Retried:   30,
+			Commited:  5,
+		},
+	)
+
+	// test that recovery state commited when rev difference > 1000
+	f(
+		func(e flowstate.Engine) {
+			var wg sync.WaitGroup
+			for i := 0; i < 1500; i++ {
+				if i%100 == 0 {
+					wg.Wait()
+				}
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					if err := e.Execute(stateCtx); err != nil {
+						t.Fatalf("failed to execute state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+
+			wg.Wait()
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     1500,
+			Completed: 1500,
+			Commited:  2,
+		},
+	)
+
+	// default retry after (2m) is respected - successful execution
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 10; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					time.Sleep(time.Second * 110)
+
+					if err := e.Execute(stateCtx); err != nil {
+						t.Fatalf("failed to execute state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     10,
+			Completed: 10,
+			Commited:  2,
+		},
+	)
+
+	// default retry after (2m) is respected - retry execution
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 10; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					time.Sleep(time.Second * 150)
+
+					if err := e.Execute(stateCtx); err != nil {
+						t.Fatalf("failed to execute state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     20,
+			Completed: 10,
+			Retried:   10,
+			Commited:  2,
+		},
+	)
+
+	// custom retry after (1m) is respected - successful execution
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 10; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+					recovery.SetRetryAfter(stateCtx, time.Minute)
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					time.Sleep(time.Second * 50)
+
+					if err := e.Execute(stateCtx); err != nil {
+						t.Fatalf("failed to execute state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     10,
+			Completed: 10,
+			Commited:  2,
+		},
+	)
+
+	// custom retry after (1m) is respected - retry execution
+	f(
+		func(e flowstate.Engine) {
+			for i := 0; i < 10; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+					recovery.SetRetryAfter(stateCtx, time.Minute)
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					time.Sleep(time.Second * 90)
+
+					if err := e.Execute(stateCtx); err != nil {
+						t.Fatalf("failed to execute state %s: %v", stateCtx.Current.ID, err)
+					}
+				}()
+			}
+		},
+		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		},
+		recovery.Stats{
+			Added:     20,
+			Completed: 10,
+			Retried:   10,
+			Commited:  2,
+		},
+	)
+}
+
+// This test simulates a cluster of two recoverers, one active and one standby.
+// The active recoverer processes states and the standby recoverer takes over if the active one is shut down.
+// The test ensures that all states are retried and processed correctly,
+// and that the standby recoverer becomes active when the active one is shut down.
+func TestRecovererActiveStandby(t *testing.T) {
+	synctest.Run(func() {
+		lh := slogassert.New(t, slog.LevelDebug, nil)
+		l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
+
+		d := memdriver.New()
+		d.SetFlow(`aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		}))
+
+		e, err := flowstate.NewEngine(d, l)
+		if err != nil {
+			t.Fatalf("failed to create engine: %v", err)
+		}
+
+		r0 := recovery.New(e, l)
+		if err := r0.Init(); err != nil {
+			t.Fatalf("failed to init recoverer: %v", err)
+		}
+
+		r1 := recovery.New(e, l)
+		if err := r1.Init(); err != nil {
+			t.Fatalf("failed to init recoverer: %v", err)
+		}
+
+		if !r0.Stats().Active {
+			t.Fatalf("expected recoverer 0 to be active, but it is not")
+		}
+		if r1.Stats().Active {
+			t.Fatalf("expected recoverer 1 to be standby, but it is active")
+		}
+
+		go func() {
+			for i := 0; i < 30; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					// just commit, do not execute, recovery should kick in
+				}()
+
+				time.Sleep(time.Second * 30)
+			}
+		}()
+
+		time.Sleep(time.Minute * 4)
+
+		if err := r0.Shutdown(context.Background()); err != nil {
+			t.Fatalf("failed to shutdown recoverer 0: %v", err)
+		}
+
+		time.Sleep(time.Second * 30)
+
+		if r0.Stats().Active {
+			t.Fatalf("expected recoverer 0 to be standby, but it is active")
+		}
+		if !r1.Stats().Active {
+			t.Fatalf("expected recoverer 1 to be active, but it is not")
+		}
+
+		time.Sleep(time.Hour)
+
+		if err := r1.Shutdown(context.Background()); err != nil {
+			t.Fatalf("failed to shutdown recoverer 1: %v", err)
+		}
+		if err := e.Shutdown(context.Background()); err != nil {
+			t.Fatalf("failed to shutdown engine: %v", err)
+		}
+		time.Sleep(time.Minute)
+
+		r0Stats := r0.Stats()
+		r1Stats := r1.Stats()
+		if 30 != r0Stats.Retried+r1Stats.Retried {
+			t.Errorf("expected retried equal to %d; got %d", 30, r0Stats.Retried+r1Stats.Retried)
+		}
+	})
+}
+
+// This test simulates a crash of the active recoverer and checks if the standby recoverer becomes active.
+// The test ensures that the standby recoverer takes over and retries the states correctly.
+func TestRecovererCrashStandbyBecomeActive(t *testing.T) {
+	synctest.Run(func() {
+		lh := slogassert.New(t, slog.LevelDebug, nil)
+		l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
+
+		d := memdriver.New()
+		d.SetFlow(`aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		}))
+
+		e, err := flowstate.NewEngine(d, l)
+		if err != nil {
+			t.Fatalf("failed to create engine: %v", err)
+		}
+
+		// simulate a crash of the active recoverer
+		// by commit state that suggest there a running recoverer
+		recoverStateCtx := &flowstate.StateCtx{
+			Current: flowstate.State{
+				ID: `flowstate.recovery.state`,
+			},
+		}
+		recovery.Disable(recoverStateCtx)
+		if err := e.Do(flowstate.Commit(
+			flowstate.Transit(recoverStateCtx, `na`),
+		)); err != nil {
+			t.Fatalf("failed to commit recovery state: %v", err)
+		}
+
+		r := recovery.New(e, l)
+		if err := r.Init(); err != nil {
+			t.Fatalf("failed to init recoverer: %v", err)
+		}
+
+		if r.Stats().Active {
+			t.Fatalf("expected recoverer to be standby, but it is active")
+		}
+
+		go func() {
+			for i := 0; i < 30; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+
+					// just commit, do not execute, recovery should kick in
+				}()
+
+				time.Sleep(time.Second * 30)
+			}
+		}()
+
+		time.Sleep(recovery.MaxRetryAfter + time.Second*80)
+		synctest.Wait()
+
+		if !r.Stats().Active {
+			t.Fatalf("expected recoverer to be active, but it is not")
+		}
+
+		time.Sleep(time.Hour)
+		synctest.Wait()
+
+		if err := r.Shutdown(context.Background()); err != nil {
+			t.Fatalf("failed to shutdown recoverer: %v", err)
+		}
+		if err := e.Shutdown(context.Background()); err != nil {
+			t.Fatalf("failed to shutdown engine: %v", err)
+		}
+		time.Sleep(time.Minute)
+		synctest.Wait()
+
+		actStats := r.Stats()
+		if 30 != actStats.Retried {
+			t.Errorf("expected retried equal to %d; got %d", 30, actStats.Retried)
+		}
+	})
+}
+
+func TestRecovererOnlyOneActive(t *testing.T) {
+	synctest.Run(func() {
+		assertOneActive := func(rs []*recovery.Recoverer) {
+			var activeCnt int
+			for _, r := range rs {
+				if r.Stats().Active {
+					activeCnt++
+				}
+			}
+			if activeCnt != 1 {
+				t.Fatalf("expected only one recoverer to be active, but got %d", activeCnt)
+			}
+		}
+
+		lh := slogassert.New(t, slog.LevelDebug, nil)
+		l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
+
+		d := memdriver.New()
+		d.SetFlow(`aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+			return flowstate.Commit(flowstate.End(stateCtx)), nil
+		}))
+
+		e, err := flowstate.NewEngine(d, l)
+		if err != nil {
+			t.Fatalf("failed to create engine: %v", err)
+		}
+
+		var rs []*recovery.Recoverer
+		for i := 0; i < 2; i++ {
+			r := recovery.New(e, l)
+			if err := r.Init(); err != nil {
+				t.Fatalf("failed to init recoverer: %v", err)
+			}
+
+			rs = append(rs, r)
+		}
+
+		assertOneActive(rs)
+
+		go func() {
+			for i := 0; i < 30; i++ {
+				go func() {
+					stateCtx := &flowstate.StateCtx{
+						Current: flowstate.State{
+							ID: flowstate.StateID("aTID" + strconv.Itoa(i)),
+						},
+					}
+
+					if err := e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `aFlow`))); err != nil {
+						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
+					}
+					e.Execute(stateCtx)
+				}()
+			}
+		}()
+
+		time.Sleep(time.Second * 30)
+		synctest.Wait()
+		assertOneActive(rs)
+
+		time.Sleep(time.Minute * 10)
+		synctest.Wait()
+		assertOneActive(rs)
+
+		for _, r := range rs {
+			if err := r.Shutdown(context.Background()); err != nil {
+				t.Fatalf("failed to shutdown recoverer: %v", err)
+			}
+		}
+		if err := e.Shutdown(context.Background()); err != nil {
+			t.Fatalf("failed to shutdown engine: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
- Adjust per state retry after duration
- Adjust per state max attempts
- Disable recovery per state 
- helpers to read Attemp\MaxAttempts
- min retry after duration changed to 1min
- max retry after duration changed to 5min
- use get many command instead of match (reduce calls number)
- improve logging
- set upper bound on recovery log size (10k items)
- persist log rev recovery reached; restore continue from logic
- horizontal recovery scalability