### PR TITLE
Revert driver Init method

### DIFF
--- a/badgerdriver/driver.go
+++ b/badgerdriver/driver.go
@@ -14,6 +14,8 @@ import (
 	"github.com/makasim/flowstate"
 )
 
+var _ flowstate.Driver = &Driver{}
+
 type Driver struct {
 	*flowstate.FlowRegistry
 
@@ -56,6 +58,10 @@ func New(db *badger.DB) (*Driver, error) {
 
 		l: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{})),
 	}, nil
+}
+
+func (d *Driver) Init(_ flowstate.Engine) error {
+	return nil
 }
 
 func (d *Driver) Shutdown(_ context.Context) error {

--- a/driver.go
+++ b/driver.go
@@ -1,14 +1,17 @@
 package flowstate
 
 type Driver interface {
+	// Init must be called by NewEngine only.
+	Init(e Engine) error
+
 	GetStateByID(cmd *GetStateByIDCommand) error
 	GetStateByLabels(cmd *GetStateByLabelsCommand) error
 	GetStates(cmd *GetStatesCommand) (*GetStatesResult, error)
 	GetDelayedStates(cmd *GetDelayedStatesCommand) (*GetDelayedStatesResult, error)
-	GetData(cmd *GetDataCommand) error
 	Delay(cmd *DelayCommand) error
-	StoreData(cmd *StoreDataCommand) error
 	Commit(cmd *CommitCommand) error
+	GetData(cmd *GetDataCommand) error
+	StoreData(cmd *StoreDataCommand) error
 
 	Flow(id FlowID) (Flow, error)
 	SetFlow(id FlowID, flow Flow) error

--- a/engine.go
+++ b/engine.go
@@ -35,6 +35,10 @@ func NewEngine(d Driver, l *slog.Logger) (Engine, error) {
 		doneCh: make(chan struct{}),
 	}
 
+	if err := d.Init(e); err != nil {
+		return nil, fmt.Errorf("driver: init: %w", err)
+	}
+
 	e.wg.Add(1)
 
 	return e, nil

--- a/memdriver/driver.go
+++ b/memdriver/driver.go
@@ -35,6 +35,10 @@ func New(l *slog.Logger) *Driver {
 	return d
 }
 
+func (d *Driver) Init(_ flowstate.Engine) error {
+	return nil
+}
+
 func (d *Driver) GetData(cmd *flowstate.GetDataCommand) error {
 	data, err := d.dataLog.get(cmd.Data.ID, cmd.Data.Rev)
 	if err != nil {

--- a/pgdriver/driver.go
+++ b/pgdriver/driver.go
@@ -12,6 +12,8 @@ import (
 	"github.com/makasim/flowstate"
 )
 
+var _ flowstate.Driver = &Driver{}
+
 type Driver struct {
 	*flowstate.FlowRegistry
 	conn  conn
@@ -30,6 +32,10 @@ func New(conn conn, l *slog.Logger) *Driver {
 		FlowRegistry: &flowstate.FlowRegistry{},
 		l:            l,
 	}
+}
+
+func (d *Driver) Init(_ flowstate.Engine) error {
+	return nil
 }
 
 func (d *Driver) GetData(cmd *flowstate.GetDataCommand) error {


### PR DESCRIPTION
The srvdriver needs access to Init in order to execute states from received from server remote calls. See https://github.com/makasim/flowstatesrv/blob/f75ca3849f40545ec0944633cde556b4addcd10a/srvdriver/handler.go#L17