### PR TITLE
impr test suite

### DIFF
--- a/badgerdriver/suite_test.go
+++ b/badgerdriver/suite_test.go
@@ -1,6 +1,7 @@
 package badgerdriver_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dgraph-io/badger/v4"
@@ -10,16 +11,26 @@ import (
 )
 
 func TestSuite(t *testing.T) {
-	s := testcases.Get(func(t testcases.TestingT) flowstate.Driver {
+	s := testcases.Get(func(t *testing.T) flowstate.Driver {
 		db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true).WithLoggingLevel(2))
 		if err != nil {
 			t.Fatalf("failed to open badger db: %v", err)
 		}
+		t.Cleanup(func() {
+			if err := db.Close(); err != nil {
+				t.Fatalf("failed to close badger db: %v", err)
+			}
+		})
 
 		d, err := badgerdriver.New(db)
 		if err != nil {
 			t.Fatalf("failed to create driver: %v", err)
 		}
+		t.Cleanup(func() {
+			if err := d.Shutdown(context.Background()); err != nil {
+				t.Fatalf("failed to close driver: %v", err)
+			}
+		})
 
 		return d
 	})

--- a/memdriver/suite_test.go
+++ b/memdriver/suite_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSuite(t *testing.T) {
-	s := testcases.Get(func(t testcases.TestingT) flowstate.Driver {
+	s := testcases.Get(func(t *testing.T) flowstate.Driver {
 		l, _ := testcases.NewTestLogger(t)
 		return memdriver.New(l)
 	})

--- a/pgdriver/suite_test.go
+++ b/pgdriver/suite_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestSuite(t *testing.T) {
-	openDB := func(t testcases.TestingT, dsn0, dbName string) *pgxpool.Pool {
-		conn := testpgdriver.OpenFreshDB(t.(*testing.T), dsn0, dbName)
+	openDB := func(t *testing.T, dsn0, dbName string) *pgxpool.Pool {
+		conn := testpgdriver.OpenFreshDB(t, dsn0, dbName)
 
 		for i, m := range pgdriver.Migrations {
 			_, err := conn.Exec(context.Background(), m.SQL)
@@ -25,7 +25,7 @@ func TestSuite(t *testing.T) {
 		return conn
 	}
 
-	s := testcases.Get(func(t testcases.TestingT) flowstate.Driver {
+	s := testcases.Get(func(t *testing.T) flowstate.Driver {
 		conn := openDB(t, `postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable`, ``)
 
 		t.Cleanup(func() {

--- a/testcases/call_flow.go
+++ b/testcases/call_flow.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func CallFlow(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func CallFlow(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	var nextStateCtx *flowstate.StateCtx
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -78,16 +75,6 @@ func CallFlow(t TestingT, d flowstate.Driver) {
 
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `call`)))
 	require.NoError(t, e.Execute(stateCtx))

--- a/testcases/call_flow_with_commit.go
+++ b/testcases/call_flow_with_commit.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func CallFlowWithCommit(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func CallFlowWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	endedCh := make(chan struct{})
 	trkr := &Tracker{}
 
@@ -82,22 +79,12 @@ func CallFlowWithCommit(t TestingT, d flowstate.Driver) {
 		return flowstate.End(stateCtx), nil
 	}))
 
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
 		},
 	}
-	err = e.Do(flowstate.Commit(
+	err := e.Do(flowstate.Commit(
 		flowstate.Transit(stateCtx, `call`),
 	))
 	require.NoError(t, err)

--- a/testcases/call_flow_with_watch.go
+++ b/testcases/call_flow_with_watch.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func CallFlowWithWatch(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func CallFlowWithWatch(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	var nextStateCtx *flowstate.StateCtx
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -94,17 +91,7 @@ func CallFlowWithWatch(t TestingT, d flowstate.Driver) {
 		), nil
 	}))
 
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
-	err = e.Do(flowstate.Commit(
+	err := e.Do(flowstate.Commit(
 		flowstate.Transit(stateCtx, `call`),
 	))
 	require.NoError(t, err)

--- a/testcases/condition.go
+++ b/testcases/condition.go
@@ -1,17 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func Condition(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func Condition(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{}
 
 	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
@@ -32,16 +28,6 @@ func Condition(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	// condition true
 	stateCtx := &flowstate.StateCtx{

--- a/testcases/data_flow_config.go
+++ b/testcases/data_flow_config.go
@@ -1,18 +1,15 @@
 package testcases
 
 import (
-	"context"
 	"encoding/json"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func DataFlowConfig(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func DataFlowConfig(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	type fooConfig struct {
 		A int `json:"a"`
 	}
@@ -124,16 +121,6 @@ func DataFlowConfig(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{

--- a/testcases/data_store_get.go
+++ b/testcases/data_store_get.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func DataStoreGet(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func DataStoreGet(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -62,16 +59,6 @@ func DataStoreGet(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `store`)))
 	require.NoError(t, e.Execute(stateCtx))

--- a/testcases/data_store_get_with_commit.go
+++ b/testcases/data_store_get_with_commit.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func DataStoreGetWithCommit(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func DataStoreGetWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -62,16 +59,6 @@ func DataStoreGetWithCommit(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `store`)))
 	require.NoError(t, e.Execute(stateCtx))

--- a/testcases/delay.go
+++ b/testcases/delay.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func Delay(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func Delay(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{}
 
 	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
@@ -26,25 +23,6 @@ func Delay(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
-	dlr, err := flowstate.NewDelayer(e, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, dlr.Shutdown(sCtx))
-	}()
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{

--- a/testcases/fork_join_first_wins.go
+++ b/testcases/fork_join_first_wins.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func ForkJoin_FirstWins(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -99,16 +96,6 @@ func ForkJoin_FirstWins(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `fork`)))
 	require.NoError(t, e.Execute(stateCtx))

--- a/testcases/fork_join_last_wins.go
+++ b/testcases/fork_join_last_wins.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func ForkJoin_LastWins(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -100,16 +97,6 @@ func ForkJoin_LastWins(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `fork`)))
 	require.NoError(t, e.Execute(stateCtx))

--- a/testcases/fork_with_commit.go
+++ b/testcases/fork_with_commit.go
@@ -1,17 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func Fork_WithCommit(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func Fork_WithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	var forkedStateCtx *flowstate.StateCtx
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -52,16 +49,6 @@ func Fork_WithCommit(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `fork`)))
 	require.NoError(t, e.Execute(stateCtx))

--- a/testcases/get_many_or_labels.go
+++ b/testcases/get_many_or_labels.go
@@ -1,28 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func GetManyORLabels(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func GetManyORLabels(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	require.NoError(t, e.Do(flowstate.Commit(
 		flowstate.Pause(&flowstate.StateCtx{
 			Current: flowstate.State{
@@ -53,21 +38,23 @@ func GetManyORLabels(t TestingT, d flowstate.Driver) {
 	require.NoError(t, e.Do(cmd))
 
 	res := cmd.MustResult()
-	require.Len(t, res.States, 2)
 	require.False(t, res.More)
 
-	actStates := res.States
+	actStates := filterSystemStates(res.States)
+	require.Len(t, actStates, 2)
 
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(1), actStates[0].Rev)
+	require.NotEmpty(t, actStates[0].Rev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 	require.Equal(t, ``, actStates[0].Labels[`bar`])
 
 	require.Equal(t, flowstate.StateID(`anotherTID`), actStates[1].ID)
-	require.Equal(t, int64(2), actStates[1].Rev)
+	require.NotEmpty(t, actStates[1].Rev)
 	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, ``, actStates[1].Labels[`foo`])
 	require.Equal(t, `barVal`, actStates[1].Labels[`bar`])
+
+	require.Greater(t, actStates[1].Rev, actStates[0].Rev)
 }

--- a/testcases/get_many_since_latest.go
+++ b/testcases/get_many_since_latest.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func GetManySinceLatest(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func GetManySinceLatest(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -46,13 +32,14 @@ func GetManySinceLatest(t TestingT, d flowstate.Driver) {
 	require.NoError(t, e.Do(cmd))
 
 	res := cmd.MustResult()
-	require.Len(t, res.States, 1)
 	require.False(t, res.More)
 
-	actStates := res.States
+	actStates := filterSystemStates(res.States)
+	require.Len(t, actStates, 1)
+
 	require.Len(t, actStates, 1)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(3), actStates[0].Rev)
+	require.NotEmpty(t, actStates[0].Rev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 }

--- a/testcases/get_many_since_rev.go
+++ b/testcases/get_many_since_rev.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func GetManySinceRev(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func GetManySinceRev(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -48,18 +34,21 @@ func GetManySinceRev(t TestingT, d flowstate.Driver) {
 	require.NoError(t, e.Do(cmd))
 
 	res := cmd.MustResult()
-	require.Len(t, res.States, 2)
 	require.False(t, res.More)
 
-	actStates := res.States
+	actStates := filterSystemStates(res.States)
+	require.Len(t, actStates, 2)
+
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(2), actStates[0].Rev)
+	require.Greater(t, actStates[0].Rev, sinceRev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[1].ID)
-	require.Equal(t, int64(3), actStates[1].Rev)
+	require.Greater(t, actStates[1].Rev, sinceRev)
 	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[1].Labels[`foo`])
+
+	require.Greater(t, actStates[1].Rev, actStates[0].Rev)
 }

--- a/testcases/get_one_by_id_and_rev.go
+++ b/testcases/get_one_by_id_and_rev.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func GetOneByIDAndRev(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func GetOneByIDAndRev(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_one_latest_by_id.go
+++ b/testcases/get_one_latest_by_id.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func GetOneLatestByID(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func GetOneLatestByID(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_one_latest_by_label.go
+++ b/testcases/get_one_latest_by_label.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func GetOneLatestByLabel(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func GetOneLatestByLabel(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_one_not_found.go
+++ b/testcases/get_one_not_found.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func GetOneNotFound(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
-	err = e.Do(flowstate.GetStateByID(&flowstate.StateCtx{}, `notExist`, 0))
+func GetOneNotFound(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+	err := e.Do(flowstate.GetStateByID(&flowstate.StateCtx{}, `notExist`, 0))
 	require.ErrorIs(t, err, flowstate.ErrNotFound)
 }

--- a/testcases/log.go
+++ b/testcases/log.go
@@ -3,11 +3,12 @@ package testcases
 import (
 	"log/slog"
 	"os"
+	"testing"
 
 	"github.com/thejerf/slogassert"
 )
 
-func NewTestLogger(t TestingT) (*slog.Logger, *slogassert.Handler) {
+func NewTestLogger(t *testing.T) (*slog.Logger, *slogassert.Handler) {
 	var wrappedH slog.Handler
 	if os.Getenv(`TEST_OUTPUT_LOG`) == `true` {
 		wrappedH = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{

--- a/testcases/mutex.go
+++ b/testcases/mutex.go
@@ -1,18 +1,15 @@
 package testcases
 
 import (
-	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func Mutex(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func Mutex(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	var raceDetector int
 
 	trkr := &Tracker{}
@@ -108,17 +105,7 @@ func Mutex(t TestingT, d flowstate.Driver) {
 		states = append(states, statesCtx)
 	}
 
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
-	err = e.Do(flowstate.Commit(
+	err := e.Do(flowstate.Commit(
 		flowstate.Pause(mutexStateCtx).WithTransit(`unlocked`),
 	))
 	require.NoError(t, err)

--- a/testcases/queue.go
+++ b/testcases/queue.go
@@ -1,18 +1,15 @@
 package testcases
 
 import (
-	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func Queue(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func Queue(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{
 		IncludeTaskID: true,
 		IncludeState:  true,
@@ -66,16 +63,6 @@ func Queue(t TestingT, d flowstate.Driver) {
 		), nil
 	}))
 
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
 	for i := 0; i < 3; i++ {
 		stateCtx := &flowstate.StateCtx{
 			Current: flowstate.State{
@@ -97,7 +84,7 @@ func Queue(t TestingT, d flowstate.Driver) {
 			ID: "enqueueTID",
 		},
 	}
-	err = e.Do(flowstate.Commit(
+	err := e.Do(flowstate.Commit(
 		flowstate.Transit(enqueueStateCtx, `enqueue`),
 	))
 	require.NoError(t, err)

--- a/testcases/rate_limit.go
+++ b/testcases/rate_limit.go
@@ -3,18 +3,16 @@ package testcases
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	"golang.org/x/time/rate"
 )
 
-func RateLimit(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func RateLimit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{
 		IncludeState: true,
 	}
@@ -88,16 +86,6 @@ func RateLimit(t TestingT, d flowstate.Driver) {
 		}
 		states = append(states, stateCtx)
 	}
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	require.NoError(t, e.Do(
 		flowstate.Commit(

--- a/testcases/single_node.go
+++ b/testcases/single_node.go
@@ -1,33 +1,19 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func SingleNode(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func SingleNode(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{}
 
 	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{

--- a/testcases/three_consequent_nodes.go
+++ b/testcases/three_consequent_nodes.go
@@ -1,17 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func ThreeConsequentNodes(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func ThreeConsequentNodes(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{}
 
 	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
@@ -26,16 +22,6 @@ func ThreeConsequentNodes(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{

--- a/testcases/tracker.go
+++ b/testcases/tracker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
@@ -62,7 +63,7 @@ func (trkr *Tracker) VisitedSorted() []string {
 	return visited
 }
 
-func (trkr *Tracker) WaitSortedVisitedEqual(t TestingT, expVisited []string, wait time.Duration) []string {
+func (trkr *Tracker) WaitSortedVisitedEqual(t *testing.T, expVisited []string, wait time.Duration) []string {
 	t.Helper()
 
 	var visited []string
@@ -75,7 +76,7 @@ func (trkr *Tracker) WaitSortedVisitedEqual(t TestingT, expVisited []string, wai
 	return visited
 }
 
-func (trkr *Tracker) WaitVisitedEqual(t TestingT, expVisited []string, wait time.Duration) []string {
+func (trkr *Tracker) WaitVisitedEqual(t *testing.T, expVisited []string, wait time.Duration) []string {
 	t.Helper()
 
 	var visited []string

--- a/testcases/two_consequent_nodes.go
+++ b/testcases/two_consequent_nodes.go
@@ -1,17 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func TwoConsequentNodes(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func TwoConsequentNodes(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{}
 
 	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
@@ -23,16 +19,6 @@ func TwoConsequentNodes(t TestingT, d flowstate.Driver) {
 		return flowstate.End(stateCtx), nil
 	}))
 
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID:  "aTID",
@@ -41,7 +27,7 @@ func TwoConsequentNodes(t TestingT, d flowstate.Driver) {
 	}
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `first`)))
-	err = e.Execute(stateCtx)
+	err := e.Execute(stateCtx)
 
 	require.NoError(t, err)
 	require.Equal(t, []string{`first`, `second`}, trkr.Visited())

--- a/testcases/two_consequent_nodes_with_commit.go
+++ b/testcases/two_consequent_nodes_with_commit.go
@@ -1,17 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func TwoConsequentNodesWithCommit(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
+func TwoConsequentNodesWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	trkr := &Tracker{}
 
 	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
@@ -24,16 +20,6 @@ func TwoConsequentNodesWithCommit(t TestingT, d flowstate.Driver) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{

--- a/testcases/watch_labels.go
+++ b/testcases/watch_labels.go
@@ -1,29 +1,15 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func WatchLabels(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func WatchLabels(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -61,18 +47,20 @@ func WatchLabels(t TestingT, d flowstate.Driver) {
 
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(1), actStates[0].Rev)
+	require.NotEmpty(t, actStates[0].Rev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[1].ID)
-	require.Equal(t, int64(2), actStates[1].Rev)
+	require.NotEmpty(t, actStates[1].Rev)
 	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[1].Labels[`foo`])
 	require.Equal(t, `barVal`, actStates[1].Labels[`bar`])
+
+	require.Greater(t, actStates[1].Rev, actStates[0].Rev)
 }
 
-func watchCollectStates(t TestingT, w *flowstate.Watcher, limit int) []flowstate.State {
+func watchCollectStates(t *testing.T, w *flowstate.Watcher, limit int) []flowstate.State {
 	var states []flowstate.State
 
 	timeoutT := time.NewTimer(time.Second)
@@ -82,6 +70,10 @@ loop:
 	for {
 		select {
 		case s := <-w.Next():
+			if len(filterSystemStates([]flowstate.State{s})) == 0 {
+				continue
+			}
+
 			assert.Greater(t, s.CommittedAtUnixMilli, int64(0))
 			// reset commited time to 0 to make test case deterministic
 			s.CommittedAtUnixMilli = 0

--- a/testcases/watch_or_labels.go
+++ b/testcases/watch_or_labels.go
@@ -1,28 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func WatchORLabels(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func WatchORLabels(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	require.NoError(t, e.Do(flowstate.Commit(
 		flowstate.Pause(&flowstate.StateCtx{
 			Current: flowstate.State{
@@ -56,14 +41,16 @@ func WatchORLabels(t TestingT, d flowstate.Driver) {
 
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(1), actStates[0].Rev)
+	require.NotEmpty(t, actStates[0].Rev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 	require.Equal(t, ``, actStates[0].Labels[`bar`])
 
 	require.Equal(t, flowstate.StateID(`anotherTID`), actStates[1].ID)
-	require.Equal(t, int64(2), actStates[1].Rev)
+	require.NotEmpty(t, actStates[1].Rev)
 	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, ``, actStates[1].Labels[`foo`])
 	require.Equal(t, `barVal`, actStates[1].Labels[`bar`])
+
+	require.Greater(t, actStates[1].Rev, actStates[0].Rev)
 }

--- a/testcases/watch_since_latest.go
+++ b/testcases/watch_since_latest.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func WatchSinceLatest(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func WatchSinceLatest(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -40,6 +26,8 @@ func WatchSinceLatest(t TestingT, d flowstate.Driver) {
 		flowstate.Pause(stateCtx),
 	)))
 
+	expRev := stateCtx.Committed.Rev
+
 	w := flowstate.NewWatcher(e, flowstate.GetStatesByLabels(map[string]string{
 		`foo`: `fooVal`,
 	}).WithSinceLatest())
@@ -49,7 +37,7 @@ func WatchSinceLatest(t TestingT, d flowstate.Driver) {
 
 	require.Len(t, actStates, 1)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(3), actStates[0].Rev)
+	require.Equal(t, expRev, actStates[0].Rev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 }

--- a/testcases/watch_since_rev.go
+++ b/testcases/watch_since_rev.go
@@ -1,27 +1,13 @@
 package testcases
 
 import (
-	"context"
-	"time"
+	"testing"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func WatchSinceRev(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	require.NoError(t, err)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func WatchSinceRev(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -51,12 +37,14 @@ func WatchSinceRev(t TestingT, d flowstate.Driver) {
 
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(2), actStates[0].Rev)
+	require.Greater(t, actStates[0].Rev, sinceRev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[1].ID)
-	require.Equal(t, int64(3), actStates[1].Rev)
+	require.Greater(t, actStates[1].Rev, sinceRev)
 	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[1].Labels[`foo`])
+
+	require.Greater(t, actStates[1].Rev, actStates[0].Rev)
 }

--- a/testcases/watch_since_time.go
+++ b/testcases/watch_since_time.go
@@ -1,26 +1,14 @@
 package testcases
 
 import (
-	"context"
+	"testing"
 	"time"
 
 	"github.com/makasim/flowstate"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
-func WatchSinceTime(t TestingT, d flowstate.Driver) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
-	l, _ := NewTestLogger(t)
-	e, err := flowstate.NewEngine(d, l)
-	defer func() {
-		sCtx, sCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer sCtxCancel()
-
-		require.NoError(t, e.Shutdown(sCtx))
-	}()
-
+func WatchSinceTime(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -44,14 +32,13 @@ func WatchSinceTime(t TestingT, d flowstate.Driver) {
 	w2 := flowstate.NewWatcher(e, flowstate.GetStatesByLabels(map[string]string{
 		`foo`: `fooVal`,
 	}).WithSinceTime(time.UnixMilli(stateCtx.Committed.CommittedAtUnixMilli-1000)))
-	require.NoError(t, err)
 	defer w2.Close()
 
 	actStates := watchCollectStates(t, w2, 1)
-
 	require.Len(t, actStates, 1)
+
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
-	require.Equal(t, int64(1), actStates[0].Rev)
+	require.NotEmpty(t, actStates[0].Rev)
 	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 }


### PR DESCRIPTION
configure engine otuside of a test  suite.
configure delayer outside of a test suites.
alow disable configuration of delayer.
check goleak after t.Cleanup is called.
remove testcases.TestingT, use testing.T
make some tests not depended on actual rev values.