### PR TITLE
Advertise and call remote flows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
           
           for file in examples/*/main.go; do
             echo "Running $file"
-            go run "$file" examples/setup.go
+            go run "$file"
             echo "----------------------"
             echo
           done

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,11 +26,7 @@ jobs:
         run: |
           set -e  # Exit on any error
           
-          for file in examples/*.go; do
-            if [[ "$file" == "examples/setup.go" ]]; then
-              continue
-            fi
-          
+          for file in examples/*/main.go; do
             echo "Running $file"
             go run "$file" examples/setup.go
             echo "----------------------"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Flowstate is a great fit when you need:
 
 ## Examples
 
-* [Durable execute](examples/durable_execute.go)
-* [Delayed execute](examples/delayed_execute.go)
-* [Execute with delay](examples/execute_with_timeout.go)
+* [Durable execute](examples/durable_execute/main.go)
+* [Delayed execute](examples/delayed_execute/main.go)
+* [Execute with delay](examples/execute_with_timeout/main.go)
 * Real-time Two-Player Game – GoGame: [Live Demo](https://gogame.makasim.com/) | [Video](https://x.com/maksim_ka2/status/1825587227163795478) | [Source Code](https://github.com/makasim/gogame).
 * [Testcases](testcases)
 

--- a/badgerdriver/driver.go
+++ b/badgerdriver/driver.go
@@ -17,7 +17,7 @@ import (
 var _ flowstate.Driver = &Driver{}
 
 type Driver struct {
-	*flowstate.FlowRegistry
+	*flowstate.DefaultFlowRegistry
 
 	db               *badger.DB
 	dataRevSeq       *badger.Sequence
@@ -54,7 +54,7 @@ func New(db *badger.DB) (*Driver, error) {
 			seq:     delayedOffsetSeq,
 			ongoing: make(map[int64]struct{}),
 		},
-		FlowRegistry: &flowstate.FlowRegistry{},
+		DefaultFlowRegistry: &flowstate.DefaultFlowRegistry{},
 
 		l: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{})),
 	}, nil

--- a/badgerdriver/driver.go
+++ b/badgerdriver/driver.go
@@ -17,8 +17,6 @@ import (
 var _ flowstate.Driver = &Driver{}
 
 type Driver struct {
-	*flowstate.DefaultFlowRegistry
-
 	db               *badger.DB
 	dataRevSeq       *badger.Sequence
 	delayedOffsetSeq *sequenceWithCommit
@@ -54,7 +52,6 @@ func New(db *badger.DB) (*Driver, error) {
 			seq:     delayedOffsetSeq,
 			ongoing: make(map[int64]struct{}),
 		},
-		DefaultFlowRegistry: &flowstate.DefaultFlowRegistry{},
 
 		l: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{})),
 	}, nil

--- a/cmd.go
+++ b/cmd.go
@@ -267,7 +267,7 @@ func (cmd *GetStateByLabelsCommand) Result() (*StateCtx, error) {
 	return cmd.StateCtx, nil
 }
 
-const GetManyDefaultLimit = 50
+const GetStatesDefaultLimit = 50
 
 type GetStatesResult struct {
 	States []State
@@ -275,7 +275,9 @@ type GetStatesResult struct {
 }
 
 func GetStatesByLabels(labels map[string]string) *GetStatesCommand {
-	return (&GetStatesCommand{}).WithORLabels(labels)
+	return (&GetStatesCommand{
+		Limit: GetStatesDefaultLimit,
+	}).WithORLabels(labels)
 }
 
 type GetStatesCommand struct {
@@ -333,9 +335,6 @@ func (cmd *GetStatesCommand) WithLimit(limit int) *GetStatesCommand {
 }
 
 func (cmd *GetStatesCommand) Prepare() {
-	if cmd.Limit == 0 {
-		cmd.Limit = GetManyDefaultLimit
-	}
 }
 
 func Noop(stateCtx *StateCtx) *NoopCommand {

--- a/driver.go
+++ b/driver.go
@@ -12,7 +12,4 @@ type Driver interface {
 	Commit(cmd *CommitCommand) error
 	GetData(cmd *GetDataCommand) error
 	StoreData(cmd *AttachDataCommand) error
-
-	Flow(id TransitionID) (Flow, error)
-	SetFlow(id TransitionID, flow Flow) error
 }

--- a/engine.go
+++ b/engine.go
@@ -19,17 +19,19 @@ type Engine interface {
 }
 
 type engine struct {
-	d Driver
-	l *slog.Logger
+	d  Driver
+	fr FlowRegistry
+	l  *slog.Logger
 
 	wg     *sync.WaitGroup
 	doneCh chan struct{}
 }
 
-func NewEngine(d Driver, l *slog.Logger) (Engine, error) {
+func NewEngine(d Driver, fr FlowRegistry, l *slog.Logger) (Engine, error) {
 	e := &engine{
-		d: d,
-		l: l,
+		d:  d,
+		fr: fr,
+		l:  l,
 
 		wg:     &sync.WaitGroup{},
 		doneCh: make(chan struct{}),
@@ -74,7 +76,7 @@ func (e *engine) Execute(stateCtx *StateCtx) error {
 			return fmt.Errorf(`transition to id empty`)
 		}
 
-		f, err := e.d.Flow(stateCtx.Current.Transition.To)
+		f, err := e.fr.Flow(stateCtx.Current.Transition.To)
 		if err != nil {
 			return err
 		}

--- a/examples/delayed_execute/main.go
+++ b/examples/delayed_execute/main.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"github.com/makasim/flowstate"
+	"github.com/makasim/flowstate/examples"
 )
 
 func main() {
 	slog.Default().Info("Example of delayed execute")
 
-	e, d, tearDown := setUp()
+	e, fr, _, tearDown := examples.SetUp()
 	defer tearDown()
 
-	err := d.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
+	err := fr.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
 		slog.Default().Info(fmt.Sprintf("executing state: %s", stateCtx.Current.ID))
 
 		// Put your business logic here
@@ -22,7 +23,7 @@ func main() {
 		// Tell the engine that the state is completed
 		return flowstate.Commit(flowstate.End(stateCtx)), nil
 	}))
-	handleError(err)
+	examples.HandleError(err)
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -38,7 +39,7 @@ func main() {
 		flowstate.Transit(stateCtx, `example`),
 		flowstate.Delay(stateCtx, time.Second*10),
 	)
-	handleError(err)
+	examples.HandleError(err)
 
 	time.Sleep(time.Second * 15)
 }

--- a/examples/durable_execute.go
+++ b/examples/durable_execute.go
@@ -10,10 +10,10 @@ import (
 func main() {
 	slog.Default().Info("Example of durable execute")
 
-	e, d, tearDown := setUp()
+	e, fr, _, tearDown := setUp()
 	defer tearDown()
 
-	err := d.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
+	err := fr.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
 		slog.Default().Info(fmt.Sprintf("executing state: %s", stateCtx.Current.ID))
 
 		// put your business logic here

--- a/examples/durable_execute/main.go
+++ b/examples/durable_execute/main.go
@@ -5,12 +5,13 @@ import (
 	"log/slog"
 
 	"github.com/makasim/flowstate"
+	"github.com/makasim/flowstate/examples"
 )
 
 func main() {
 	slog.Default().Info("Example of durable execute")
 
-	e, fr, _, tearDown := setUp()
+	e, fr, _, tearDown := examples.SetUp()
 	defer tearDown()
 
 	err := fr.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
@@ -21,7 +22,7 @@ func main() {
 		// Tell the engine that the state is completed
 		return flowstate.Commit(flowstate.End(stateCtx)), nil
 	}))
-	handleError(err)
+	examples.HandleError(err)
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -32,10 +33,10 @@ func main() {
 	// After the state is commited it is guaranteed that the state will be executed
 	// at least flowstate.DefaultMaxRecoveryAttempts attempts
 	err = e.Do(flowstate.Commit(flowstate.Transit(stateCtx, `example`)))
-	handleError(err)
+	examples.HandleError(err)
 
 	// Execute the state synchronously
 	// The engine will call the example flow.
 	err = e.Execute(stateCtx)
-	handleError(err)
+	examples.HandleError(err)
 }

--- a/examples/execute_with_timeout/main.go
+++ b/examples/execute_with_timeout/main.go
@@ -7,15 +7,16 @@ import (
 	"time"
 
 	"github.com/makasim/flowstate"
+	"github.com/makasim/flowstate/examples"
 )
 
 func main() {
 	slog.Default().Info("Example of delayed execute")
 
-	e, d, tearDown := setUp()
+	e, fr, _, tearDown := examples.SetUp()
 	defer tearDown()
 
-	err := d.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
+	err := fr.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
 		// The condition succeeds if the main execution timed out.
 		// The delayed task wont be executed if the state was completed before the timeout.
 		if flowstate.Delayed(stateCtx.Current) {
@@ -34,7 +35,7 @@ func main() {
 		// Tell the engine that the state is completed
 		return flowstate.Commit(flowstate.End(stateCtx)), nil
 	}))
-	handleError(err)
+	examples.HandleError(err)
 
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -51,7 +52,7 @@ func main() {
 		),
 		flowstate.Execute(stateCtx),
 	)
-	handleError(err)
+	examples.HandleError(err)
 
 	time.Sleep(time.Second * 15)
 }

--- a/examples/setup.go
+++ b/examples/setup.go
@@ -1,4 +1,4 @@
-package main
+package examples
 
 import (
 	"context"
@@ -8,29 +8,29 @@ import (
 	"github.com/makasim/flowstate/memdriver"
 )
 
-func setUp() (flowstate.Engine, flowstate.FlowRegistry, flowstate.Driver, func()) {
+func SetUp() (flowstate.Engine, flowstate.FlowRegistry, flowstate.Driver, func()) {
 	d := memdriver.New(slog.Default())
 	fr := &flowstate.DefaultFlowRegistry{}
 
 	e, err := flowstate.NewEngine(d, fr, slog.Default())
-	handleError(err)
+	HandleError(err)
 
 	r, err := flowstate.NewRecoverer(e, slog.Default())
-	handleError(err)
+	HandleError(err)
 
 	dlr, err := flowstate.NewDelayer(e, slog.Default())
-	handleError(err)
+	HandleError(err)
 
 	return e, fr, d, func() {
 		err := dlr.Shutdown(context.Background())
-		handleError(err)
+		HandleError(err)
 
 		err = r.Shutdown(context.Background())
-		handleError(err)
+		HandleError(err)
 	}
 }
 
-func handleError(err error) {
+func HandleError(err error) {
 	if err != nil {
 		panic(err)
 	}

--- a/examples/setup.go
+++ b/examples/setup.go
@@ -8,10 +8,11 @@ import (
 	"github.com/makasim/flowstate/memdriver"
 )
 
-func setUp() (flowstate.Engine, flowstate.Driver, func()) {
+func setUp() (flowstate.Engine, flowstate.FlowRegistry, flowstate.Driver, func()) {
 	d := memdriver.New(slog.Default())
+	fr := &flowstate.DefaultFlowRegistry{}
 
-	e, err := flowstate.NewEngine(d, slog.Default())
+	e, err := flowstate.NewEngine(d, fr, slog.Default())
 	handleError(err)
 
 	r, err := flowstate.NewRecoverer(e, slog.Default())
@@ -20,7 +21,7 @@ func setUp() (flowstate.Engine, flowstate.Driver, func()) {
 	dlr, err := flowstate.NewDelayer(e, slog.Default())
 	handleError(err)
 
-	return e, d, func() {
+	return e, fr, d, func() {
 		err := dlr.Shutdown(context.Background())
 		handleError(err)
 

--- a/memdriver/driver.go
+++ b/memdriver/driver.go
@@ -13,8 +13,6 @@ import (
 var _ flowstate.Driver = &Driver{}
 
 type Driver struct {
-	*flowstate.FlowRegistry
-
 	stateLog        *stateLog
 	dataLog         *dataLog
 	delayedStateLog *delayedStateLog
@@ -27,7 +25,6 @@ func New(l *slog.Logger) *Driver {
 		stateLog:        &stateLog{},
 		dataLog:         &dataLog{},
 		delayedStateLog: &delayedStateLog{},
-		FlowRegistry:    &flowstate.FlowRegistry{},
 
 		l: l,
 	}

--- a/netdriver/driver.go
+++ b/netdriver/driver.go
@@ -13,8 +13,6 @@ import (
 var _ flowstate.Driver = (*Driver)(nil)
 
 type Driver struct {
-	flowstate.FlowRegistry
-
 	httpHost string
 
 	c *http.Client

--- a/netflow/flow_test.go
+++ b/netflow/flow_test.go
@@ -19,15 +19,16 @@ func TestFlowExecute(t *testing.T) {
 	l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
 
 	d := memdriver.New(l)
+	fr := &flowstate.DefaultFlowRegistry{}
 	executedCh := make(chan struct{})
-	if err := d.SetFlow(`aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
+	if err := fr.SetFlow(`aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
 		close(executedCh)
 		return flowstate.End(stateCtx), nil
 	})); err != nil {
 		t.Fatalf("failed to set flow: %v", err)
 	}
 
-	e, err := flowstate.NewEngine(d, l)
+	e, err := flowstate.NewEngine(d, fr, l)
 	if err != nil {
 		t.Fatalf("failed to create flowstate engine: %v", err)
 	}

--- a/netflow/registry.go
+++ b/netflow/registry.go
@@ -1,0 +1,206 @@
+package netflow
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/makasim/flowstate"
+)
+
+var _ flowstate.FlowRegistry = (*Registry)(nil)
+
+type Registry struct {
+	httpHost string
+	fr       *flowstate.DefaultFlowRegistry
+	d        flowstate.Driver
+	l        *slog.Logger
+
+	hostsFlowsMux sync.Mutex
+	hostFlows     map[string]*Flow
+	closeCh       chan struct{}
+	closedCh      chan struct{}
+}
+
+func NewRegistry(httpHost string, d flowstate.Driver, l *slog.Logger) *Registry {
+	fr := &Registry{
+		d:        d,
+		l:        l,
+		httpHost: httpHost,
+
+		fr:       &flowstate.DefaultFlowRegistry{},
+		closeCh:  make(chan struct{}),
+		closedCh: make(chan struct{}),
+	}
+
+	go fr.watchFlows()
+
+	return fr
+}
+
+func (fr *Registry) Flow(id flowstate.TransitionID) (flowstate.Flow, error) {
+	return fr.fr.Flow(id)
+}
+
+func (fr *Registry) SetFlow(id flowstate.TransitionID, flow flowstate.Flow) error {
+	if err := fr.fr.SetFlow(id, flow); err != nil {
+		return err
+	}
+
+	stateCtx := &flowstate.StateCtx{
+		Current: flowstate.State{
+			ID: flowStateID(id),
+		},
+	}
+	err := fr.d.GetStateByID(flowstate.GetStateByID(stateCtx, stateCtx.Current.ID, 0))
+	if errors.Is(err, flowstate.ErrNotFound) {
+		// ok
+	} else if err != nil {
+		return fmt.Errorf("get state by id: %w", err)
+	}
+
+	if stateCtx.Current.Annotations[`flowstate.flow.http_host`] == fr.httpHost {
+		return nil
+	}
+
+	stateCtx.Current.SetLabel(`flow.type`, `remote`)
+	stateCtx.Current.SetAnnotation(`flowstate.flow.transition_id`, string(id))
+	stateCtx.Current.SetAnnotation(`flowstate.flow.http_host`, fr.httpHost)
+
+	if err := fr.d.Commit(flowstate.Commit(flowstate.Pause(stateCtx))); flowstate.IsErrRevMismatch(err) {
+		// ok
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("commit flow state: %w", err)
+	}
+
+	return nil
+}
+
+func (fr *Registry) UnsetFlow(id flowstate.TransitionID) error {
+	f0, err := fr.fr.Flow(id)
+	if errors.Is(err, flowstate.ErrNotFound) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("get flow: %w", err)
+	}
+
+	if err := fr.fr.UnsetFlow(id); err != nil {
+		return err
+	}
+
+	if _, ok := f0.(*Flow); ok {
+		return nil
+	}
+
+	fr.hostsFlowsMux.Lock()
+	defer fr.hostsFlowsMux.Unlock()
+
+	stateCtx := &flowstate.StateCtx{
+		Current: flowstate.State{
+			ID: flowStateID(id),
+		},
+	}
+	if err = fr.d.GetStateByID(flowstate.GetStateByID(stateCtx, stateCtx.Current.ID, 0)); err != nil {
+		return fmt.Errorf("get state by id: %w", err)
+	}
+
+	if err := fr.d.Commit(flowstate.Commit(flowstate.End(stateCtx))); flowstate.IsErrRevMismatch(err) {
+		// ok
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("commit flow state: %w", err)
+	}
+
+	return nil
+}
+
+func (fr *Registry) Close() {
+	close(fr.closeCh)
+	<-fr.closedCh
+}
+
+func (fr *Registry) watchFlows() {
+	defer close(fr.closedCh)
+
+	t := time.NewTicker(time.Second * 10)
+	defer t.Stop()
+
+	labels := map[string]string{`flow.type`: `remote`}
+	getStatesCmd := flowstate.GetStatesByLabels(labels).WithLatestOnly()
+
+	for {
+		fr.l.Debug("get states", "labels", labels, "latest_only", true, "since_rev", getStatesCmd.SinceRev)
+
+		if err := fr.d.GetStates(getStatesCmd); err != nil {
+			fr.l.Error("driver: get states failed", "error", err)
+			continue
+		}
+
+		res := getStatesCmd.MustResult()
+
+		for _, state := range res.States {
+			getStatesCmd.SinceRev = state.Rev
+
+			if state.Annotations[`flowstate.flow.http_host`] == `` {
+				fr.l.Warn("state has no 'flowstate.flow.http_host' annotation set, skipping", "state_id", state.ID, "state_rev", state.Rev)
+				continue
+			}
+			httpHost := state.Annotations[`flowstate.flow.http_host`]
+
+			// local flow, skip
+			if httpHost == fr.httpHost {
+				continue
+			}
+
+			if state.Annotations[`flowstate.flow.transition_id`] == `` {
+				fr.l.Warn("flow state has no 'flowstate.flow.transition_id' annotation set, skipping", "state_id", state.ID, "state_rev", state.Rev)
+				continue
+			}
+			tsID := flowstate.TransitionID(state.Annotations[`flowstate.flow.transition_id`])
+
+			if flowstate.Ended(state) {
+				if err := fr.fr.UnsetFlow(tsID); err != nil {
+					fr.l.Warn("flow registry: unset flow failed", "error", err, "transition_id", tsID, "state_id", state.ID, "state_rev", state.Rev)
+				}
+
+				continue
+			}
+
+			fr.hostsFlowsMux.Lock()
+
+			if fr.hostFlows == nil {
+				fr.hostFlows = make(map[string]*Flow)
+			}
+
+			f, ok := fr.hostFlows[httpHost]
+			if !ok {
+				f = New(httpHost)
+				fr.hostFlows[httpHost] = f
+			}
+
+			fr.hostsFlowsMux.Unlock()
+
+			if err := fr.fr.SetFlow(tsID, f); err != nil {
+				fr.l.Warn("flow registry: set flow failed", "error", err, "transition_id", tsID, "state_id", state.ID, "state_rev", state.Rev)
+			}
+		}
+
+		if res.More {
+			continue
+		}
+
+		select {
+		case <-t.C:
+			continue
+		case <-fr.closeCh:
+			return
+		}
+	}
+}
+
+func flowStateID(tsID flowstate.TransitionID) flowstate.StateID {
+	return flowstate.StateID(`flowstate.flow.` + string(tsID))
+}

--- a/netflow/registry_synctest_test.go
+++ b/netflow/registry_synctest_test.go
@@ -1,0 +1,145 @@
+//go:build goexperiment.synctest
+
+package netflow_test
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/makasim/flowstate"
+	"github.com/makasim/flowstate/memdriver"
+	"github.com/makasim/flowstate/netflow"
+	"github.com/thejerf/slogassert"
+)
+
+func TestRegistry(t *testing.T) {
+	synctest.Run(func() {
+		lh := slogassert.New(t, slog.LevelDebug, nil)
+		l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
+
+		d := memdriver.New(l)
+
+		firstFR := netflow.NewRegistry(`http://first:8080`, d, l)
+		defer firstFR.Close()
+
+		secondFR := netflow.NewRegistry(`http://second:8080`, d, l)
+		defer secondFR.Close()
+
+		// make sure we skiped the first round of Registry.watchFlows call
+		time.Sleep(time.Second * 5)
+
+		if err := firstFR.SetFlow(`aFlowOnFirstFR`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
+			panic("should not be called")
+			return nil, nil
+		})); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if err := secondFR.SetFlow(`aFlowOnSecondFR`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
+			panic("should not be called")
+			return nil, nil
+		})); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// only local flows should be available
+
+		if _, err := firstFR.Flow(`aFlowOnFirstFR`); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if _, err := firstFR.Flow(`aFlowOnSecondFR`); err == nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if _, err := secondFR.Flow(`aFlowOnSecondFR`); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if _, err := secondFR.Flow(`aFlowOnFirstFR`); err == nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		time.Sleep(time.Second * 7)
+
+		// now we should be able to get all flows
+
+		f0, err := firstFR.Flow(`aFlowOnFirstFR`)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if f0 == nil {
+			t.Fatalf("expected non-nil flow, got nil")
+		}
+		if _, ok := f0.(flowstate.FlowFunc); !ok {
+			t.Fatalf("expected flow to be of type FlowFunc, got %T", f0)
+		}
+
+		f0, err = firstFR.Flow(`aFlowOnSecondFR`)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if f0 == nil {
+			t.Fatalf("expected non-nil flow, got nil")
+		}
+		if _, ok := f0.(*netflow.Flow); !ok {
+			t.Fatalf("expected flow to be of type FlowFunc, got %T", f0)
+		}
+
+		f0, err = secondFR.Flow(`aFlowOnSecondFR`)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if f0 == nil {
+			t.Fatalf("expected non-nil flow, got nil")
+		}
+		if _, ok := f0.(flowstate.FlowFunc); !ok {
+			t.Fatalf("expected flow to be of type FlowFunc, got %T", f0)
+		}
+
+		f0, err = secondFR.Flow(`aFlowOnFirstFR`)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if f0 == nil {
+			t.Fatalf("expected non-nil flow, got nil")
+		}
+		if _, ok := f0.(*netflow.Flow); !ok {
+			t.Fatalf("expected flow to be of type FlowFunc, got %T", f0)
+		}
+
+		// unset flows
+
+		if err := firstFR.UnsetFlow(`aFlowOnFirstFR`); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if err := firstFR.UnsetFlow(`aFlowOnSecondFR`); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if err := secondFR.UnsetFlow(`aFlowOnFirstFR`); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if err := secondFR.UnsetFlow(`aFlowOnSecondFR`); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// wait for watchFlows to sync
+		time.Sleep(time.Second * 12)
+
+		// no flows should be available now
+
+		if _, err = firstFR.Flow(`aFlowOnFirstFR`); !errors.Is(err, flowstate.ErrFlowNotFound) {
+			t.Fatalf("expected flow not found error, got %v", err)
+		}
+		if _, err = firstFR.Flow(`aFlowOnSecondFR`); !errors.Is(err, flowstate.ErrFlowNotFound) {
+			t.Fatalf("expected flow not found error, got %v", err)
+		}
+		if _, err = secondFR.Flow(`aFlowOnFirstFR`); !errors.Is(err, flowstate.ErrFlowNotFound) {
+			t.Fatalf("expected flow not found error, got %v", err)
+		}
+		if _, err = secondFR.Flow(`aFlowOnSecondFR`); !errors.Is(err, flowstate.ErrFlowNotFound) {
+			t.Fatalf("expected flow not found error, got %v", err)
+		}
+	})
+}

--- a/pgdriver/driver.go
+++ b/pgdriver/driver.go
@@ -15,7 +15,6 @@ import (
 var _ flowstate.Driver = &Driver{}
 
 type Driver struct {
-	*flowstate.FlowRegistry
 	conn  conn
 	q     *queries
 	doers []flowstate.Driver
@@ -27,10 +26,9 @@ type Driver struct {
 func New(conn conn, l *slog.Logger) *Driver {
 	return &Driver{
 		conn: conn,
-
-		q:            &queries{},
-		FlowRegistry: &flowstate.FlowRegistry{},
-		l:            l,
+		l:    l,
+		
+		q: &queries{},
 	}
 }
 

--- a/recovery_synctest_test.go
+++ b/recovery_synctest_test.go
@@ -25,9 +25,10 @@ func TestRecovererRetryLogic(t *testing.T) {
 			l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
 
 			d := memdriver.New(l)
-			mustSetFlow(d, `aFlow`, flowFn)
+			fr := &flowstate.DefaultFlowRegistry{}
+			mustSetFlow(fr, `aFlow`, flowFn)
 
-			e, err := flowstate.NewEngine(d, l)
+			e, err := flowstate.NewEngine(d, fr, l)
 			if err != nil {
 				t.Fatalf("failed to create engine: %v", err)
 			}
@@ -505,11 +506,12 @@ func TestRecovererActiveStandby(t *testing.T) {
 		l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
 
 		d := memdriver.New(l)
-		mustSetFlow(d, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+		fr := &flowstate.DefaultFlowRegistry{}
+		mustSetFlow(fr, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 			return flowstate.Commit(flowstate.End(stateCtx)), nil
 		}))
 
-		e, err := flowstate.NewEngine(d, l)
+		e, err := flowstate.NewEngine(d, fr, l)
 		if err != nil {
 			t.Fatalf("failed to create engine: %v", err)
 		}
@@ -592,11 +594,12 @@ func TestRecovererCrashStandbyBecomeActive(t *testing.T) {
 		l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
 
 		d := memdriver.New(l)
-		mustSetFlow(d, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+		fr := &flowstate.DefaultFlowRegistry{}
+		mustSetFlow(fr, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 			return flowstate.Commit(flowstate.End(stateCtx)), nil
 		}))
 
-		e, err := flowstate.NewEngine(d, l)
+		e, err := flowstate.NewEngine(d, fr, l)
 		if err != nil {
 			t.Fatalf("failed to create engine: %v", err)
 		}
@@ -688,11 +691,12 @@ func TestRecovererOnlyOneActive(t *testing.T) {
 		l := slog.New(slogassert.New(t, slog.LevelDebug, lh))
 
 		d := memdriver.New(l)
-		mustSetFlow(d, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+		fr := &flowstate.DefaultFlowRegistry{}
+		mustSetFlow(fr, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 			return flowstate.Commit(flowstate.End(stateCtx)), nil
 		}))
 
-		e, err := flowstate.NewEngine(d, l)
+		e, err := flowstate.NewEngine(d, fr, l)
 		if err != nil {
 			t.Fatalf("failed to create engine: %v", err)
 		}

--- a/testcases/actor.go
+++ b/testcases/actor.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Actor(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Actor(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{IncludeTaskID: true}
 
-	mustSetFlow(d, "actor", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "actor", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		w := flowstate.NewWatcher(e, flowstate.GetStatesByLabels(map[string]string{
 			"actor.foo": "inbox",
@@ -39,7 +39,7 @@ func Actor(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 			}
 		}
 	}))
-	mustSetFlow(d, "inbox", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "inbox", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		return nil, fmt.Errorf("must never be executed")
 	}))
 

--- a/testcases/call_flow.go
+++ b/testcases/call_flow.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func CallFlow(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func CallFlow(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	var nextStateCtx *flowstate.StateCtx
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -19,7 +19,7 @@ func CallFlow(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	endedCh := make(chan struct{})
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "call", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "call", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if flowstate.Resumed(stateCtx.Current) {
@@ -43,11 +43,11 @@ func CallFlow(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(stateCtx), nil
 	}))
-	mustSetFlow(d, "called", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "called", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Transit(stateCtx, `calledEnd`), nil
 	}))
-	mustSetFlow(d, "calledEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "calledEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if stateCtx.Current.Annotations[`caller_state`] != "" {
@@ -68,7 +68,7 @@ func CallFlow(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 		return flowstate.End(stateCtx), nil
 	}))
 
-	mustSetFlow(d, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		close(endedCh)

--- a/testcases/call_flow_with_commit.go
+++ b/testcases/call_flow_with_commit.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func CallFlowWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func CallFlowWithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	endedCh := make(chan struct{})
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "call", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "call", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if flowstate.Resumed(stateCtx.Current) {
@@ -38,7 +38,7 @@ func CallFlowWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(stateCtx), nil
 	}))
-	mustSetFlow(d, "called", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "called", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if err := e.Do(
@@ -50,7 +50,7 @@ func CallFlowWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(stateCtx), nil
 	}))
-	mustSetFlow(d, "calledEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "calledEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		if stateCtx.Current.Annotations[`caller_state`] != "" {
 			callStateCtx := &flowstate.StateCtx{}
@@ -71,7 +71,7 @@ func CallFlowWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.End(stateCtx), nil
 	}))
-	mustSetFlow(d, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		close(endedCh)

--- a/testcases/call_flow_with_watch.go
+++ b/testcases/call_flow_with_watch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func CallFlowWithWatch(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func CallFlowWithWatch(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	var nextStateCtx *flowstate.StateCtx
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -20,7 +20,7 @@ func CallFlowWithWatch(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "call", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "call", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if stateCtx.Current.Annotations[`called`] == `` {
@@ -70,18 +70,18 @@ func CallFlowWithWatch(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 		}
 
 	}))
-	mustSetFlow(d, "called", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "called", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Transit(stateCtx, `calledEnd`), nil
 	}))
-	mustSetFlow(d, "calledEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "calledEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		return flowstate.Commit(
 			flowstate.End(stateCtx),
 		), nil
 	}))
-	mustSetFlow(d, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		close(endedCh)

--- a/testcases/condition.go
+++ b/testcases/condition.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Condition(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Condition(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		bID := flowstate.TransitionID(`third`)
@@ -20,11 +20,11 @@ func Condition(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Transit(stateCtx, bID), nil
 	}))
-	mustSetFlow(d, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-	mustSetFlow(d, "third", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "third", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/cron.go
+++ b/testcases/cron.go
@@ -11,10 +11,10 @@ import (
 	//"go.uber.org/goleak"
 )
 
-func Cron(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "cron", flowstate.FlowFunc(func(cronStateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "cron", flowstate.FlowFunc(func(cronStateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(cronStateCtx, trkr)
 
 		now := time.Now()
@@ -78,7 +78,7 @@ func Cron(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(cronStateCtx), nil
 	}))
-	mustSetFlow(d, "task", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "task", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Commit(
 			flowstate.End(stateCtx),

--- a/testcases/data_flow_config.go
+++ b/testcases/data_flow_config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func DataFlowConfig(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func DataFlowConfig(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	type fooConfig struct {
 		A int `json:"a"`
 	}
@@ -33,7 +33,7 @@ func DataFlowConfig(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "foo", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "foo", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		data := &flowstate.Data{}
@@ -71,7 +71,7 @@ func DataFlowConfig(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Execute(stateCtx), nil
 	}))
-	mustSetFlow(d, "bar", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "bar", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		data := &flowstate.Data{}
@@ -111,7 +111,7 @@ func DataFlowConfig(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Execute(stateCtx), nil
 	}))
-	mustSetFlow(d, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/data_store_get.go
+++ b/testcases/data_store_get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func DataStoreGet(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func DataStoreGet(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -24,7 +24,7 @@ func DataStoreGet(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 	}
 	actData := &flowstate.Data{}
 
-	mustSetFlow(d, "store", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "store", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		d := &flowstate.Data{
@@ -41,7 +41,7 @@ func DataStoreGet(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Execute(stateCtx), nil
 	}))
-	mustSetFlow(d, "get", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "get", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if err := e.Do(
@@ -53,7 +53,7 @@ func DataStoreGet(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Execute(stateCtx), nil
 	}))
-	mustSetFlow(d, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/data_store_get_with_commit.go
+++ b/testcases/data_store_get_with_commit.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func DataStoreGetWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func DataStoreGetWithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -24,7 +24,7 @@ func DataStoreGetWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver
 	}
 	actData := &flowstate.Data{}
 
-	mustSetFlow(d, "store", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "store", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		d := &flowstate.Data{
@@ -41,7 +41,7 @@ func DataStoreGetWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver
 
 		return flowstate.Execute(stateCtx), nil
 	}))
-	mustSetFlow(d, "get", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "get", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if err := e.Do(flowstate.Commit(
@@ -53,7 +53,7 @@ func DataStoreGetWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver
 
 		return flowstate.Execute(stateCtx), nil
 	}))
-	mustSetFlow(d, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/delay.go
+++ b/testcases/delay.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Delay(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Delay(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		if flowstate.Delayed(stateCtx.Current) {
 			return flowstate.Transit(stateCtx, `second`), nil
@@ -19,7 +19,7 @@ func Delay(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Delay(stateCtx, time.Millisecond*200), nil
 	}))
-	mustSetFlow(d, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/fork.go
+++ b/testcases/fork.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Fork(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Fork(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	var forkedStateCtx *flowstate.StateCtx
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -18,7 +18,7 @@ func Fork(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		forkedStateCtx = &flowstate.StateCtx{}
@@ -39,11 +39,11 @@ func Fork(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(stateCtx), nil
 	}))
-	mustSetFlow(d, "origin", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "origin", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
-	mustSetFlow(d, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/fork_join_first_wins.go
+++ b/testcases/fork_join_first_wins.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -17,7 +17,7 @@ func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		stateCtx.Current.SetLabel(`theForkJoinLabel`, string(stateCtx.Current.ID))
@@ -40,7 +40,7 @@ func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(stateCtx), nil
 	}))
-	mustSetFlow(d, "join", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "join", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if stateCtx.Committed.Transition.To != `join` {
@@ -87,12 +87,12 @@ func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 		}
 	}))
 
-	mustSetFlow(d, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Transit(stateCtx, `join`), nil
 	}))
 
-	mustSetFlow(d, "joined", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "joined", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/fork_join_last_wins.go
+++ b/testcases/fork_join_last_wins.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",
@@ -17,7 +17,7 @@ func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		stateCtx.Current.SetLabel(`theForkJoinLabel`, string(stateCtx.Current.ID))
@@ -41,7 +41,7 @@ func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(stateCtx), nil
 	}))
-	mustSetFlow(d, "join", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "join", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if stateCtx.Committed.Transition.To != `join` {
@@ -88,12 +88,12 @@ func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 		}
 	}))
 
-	mustSetFlow(d, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Transit(stateCtx, `join`), nil
 	}))
 
-	mustSetFlow(d, "joined", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "joined", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/fork_with_commit.go
+++ b/testcases/fork_with_commit.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Fork_WithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Fork_WithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	var forkedStateCtx *flowstate.StateCtx
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
@@ -18,7 +18,7 @@ func Fork_WithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "fork", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		forkedStateCtx = &flowstate.StateCtx{}
@@ -40,12 +40,12 @@ func Fork_WithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		return flowstate.Noop(stateCtx), nil
 	}))
-	mustSetFlow(d, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))
 
-	mustSetFlow(d, "origin", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "origin", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/get_many_labels.go
+++ b/testcases/get_many_labels.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetManyLabels(t *testing.T, e flowstate.Engine, _ flowstate.Driver) {
+func GetManyLabels(t *testing.T, e flowstate.Engine, _ flowstate.FlowRegistry, _ flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_many_latest_only.go
+++ b/testcases/get_many_latest_only.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetManyLatestOnly(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetManyLatestOnly(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_many_or_labels.go
+++ b/testcases/get_many_or_labels.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetManyORLabels(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetManyORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	require.NoError(t, e.Do(flowstate.Commit(
 		flowstate.Pause(&flowstate.StateCtx{
 			Current: flowstate.State{

--- a/testcases/get_many_since_latest.go
+++ b/testcases/get_many_since_latest.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetManySinceLatest(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetManySinceLatest(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_many_since_rev.go
+++ b/testcases/get_many_since_rev.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetManySinceRev(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetManySinceRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_many_since_time.go
+++ b/testcases/get_many_since_time.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetManySinceTime(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetManySinceTime(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_one_by_id_and_rev.go
+++ b/testcases/get_one_by_id_and_rev.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetOneByIDAndRev(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetOneByIDAndRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_one_latest_by_id.go
+++ b/testcases/get_one_latest_by_id.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetOneLatestByID(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetOneLatestByID(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_one_latest_by_label.go
+++ b/testcases/get_one_latest_by_label.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetOneLatestByLabel(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetOneLatestByLabel(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/get_one_not_found.go
+++ b/testcases/get_one_not_found.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func GetOneNotFound(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func GetOneNotFound(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	err := e.Do(flowstate.GetStateByID(&flowstate.StateCtx{}, `notExist`, 0))
 	require.ErrorIs(t, err, flowstate.ErrNotFound)
 }

--- a/testcases/mutex.go
+++ b/testcases/mutex.go
@@ -9,15 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Mutex(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Mutex(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	var raceDetector int
 
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "mutex", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "mutex", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		return nil, fmt.Errorf("must not be called; mutex is always paused")
 	}))
-	mustSetFlow(d, "lock", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "lock", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		w := flowstate.NewWatcher(e, flowstate.GetStatesByLabels(map[string]string{"mutex": "theName"}).WithSinceLatest())
@@ -64,14 +64,14 @@ func Mutex(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 
 		}
 	}))
-	mustSetFlow(d, "protected", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "protected", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		raceDetector += 1
 
 		return flowstate.Transit(stateCtx, `unlock`), nil
 	}))
-	mustSetFlow(d, "unlock", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "unlock", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		mutexStateCtx := &flowstate.StateCtx{}

--- a/testcases/queue.go
+++ b/testcases/queue.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Queue(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func Queue(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{
 		IncludeTaskID: true,
 		IncludeState:  true,
 	}
 
-	mustSetFlow(d, "queue", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "queue", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		if flowstate.Resumed(stateCtx.Current) {
 			return flowstate.Transit(stateCtx, `dequeued`), nil
@@ -27,7 +27,7 @@ func Queue(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 			flowstate.Pause(stateCtx),
 		), nil
 	}))
-	mustSetFlow(d, "enqueue", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "enqueue", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		w := flowstate.NewWatcher(e, flowstate.GetStatesByLabels(map[string]string{
@@ -56,7 +56,7 @@ func Queue(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 			}
 		}
 	}))
-	mustSetFlow(d, "dequeued", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "dequeued", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Commit(
 			flowstate.End(stateCtx),

--- a/testcases/rate_limit.go
+++ b/testcases/rate_limit.go
@@ -12,12 +12,12 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func RateLimit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func RateLimit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{
 		IncludeState: true,
 	}
 
-	mustSetFlow(d, "limiter", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "limiter", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		// The zero value of Sometimes behaves like sync.Once, though less efficiently.
 		l := rate.NewLimiter(rate.Every(time.Millisecond*100), 1)
 
@@ -54,7 +54,7 @@ func RateLimit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
 			}
 		}
 	}))
-	mustSetFlow(d, "limited", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "limited", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		if flowstate.Resumed(stateCtx.Current) {

--- a/testcases/single_node.go
+++ b/testcases/single_node.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func SingleNode(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func SingleNode(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/suite.go
+++ b/testcases/suite.go
@@ -15,7 +15,7 @@ type Suite struct {
 	SetUpDelayer bool
 
 	disableGoleak bool
-	cases         map[string]func(t *testing.T, e flowstate.Engine, d flowstate.Driver)
+	cases         map[string]func(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver)
 }
 
 func (s *Suite) Test(main *testing.T) {
@@ -37,10 +37,12 @@ func (s *Suite) run(main *testing.T, name string) {
 			t.SkipNow()
 		}
 
-		d := s.SetUp(t)
-
 		l, _ := NewTestLogger(t)
-		e, err := flowstate.NewEngine(d, l)
+
+		d := s.SetUp(t)
+		fr := &flowstate.DefaultFlowRegistry{}
+
+		e, err := flowstate.NewEngine(d, fr, l)
 		if err != nil {
 			t.Fatalf("failed to create engine: %v", err)
 		}
@@ -68,7 +70,7 @@ func (s *Suite) run(main *testing.T, name string) {
 			})
 		}
 
-		fn(t, e, d)
+		fn(t, e, fr, d)
 	})
 }
 
@@ -89,7 +91,7 @@ func Get(setUp func(t *testing.T) flowstate.Driver) *Suite {
 		SetUp:        setUp,
 		SetUpDelayer: true,
 
-		cases: map[string]func(t *testing.T, e flowstate.Engine, d flowstate.Driver){
+		cases: map[string]func(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver){
 			"Actor": Actor,
 
 			"CallFlow":           CallFlow,

--- a/testcases/three_consequent_nodes.go
+++ b/testcases/three_consequent_nodes.go
@@ -7,18 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ThreeConsequentNodes(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func ThreeConsequentNodes(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Transit(stateCtx, `second`), nil
 	}))
-	mustSetFlow(d, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Transit(stateCtx, `third`), nil
 	}))
-	mustSetFlow(d, "third", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "third", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/tracker.go
+++ b/testcases/tracker.go
@@ -89,8 +89,8 @@ func (trkr *Tracker) WaitVisitedEqual(t *testing.T, expVisited []string, wait ti
 	return visited
 }
 
-func mustSetFlow(d flowstate.Driver, id flowstate.TransitionID, f flowstate.Flow) {
-	if err := d.SetFlow(id, f); err != nil {
+func mustSetFlow(fr flowstate.FlowRegistry, id flowstate.TransitionID, f flowstate.Flow) {
+	if err := fr.SetFlow(id, f); err != nil {
 		panic(fmt.Sprintf("set flow %s: %s", id, err))
 	}
 }

--- a/testcases/two_consequent_nodes.go
+++ b/testcases/two_consequent_nodes.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TwoConsequentNodes(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func TwoConsequentNodes(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Transit(stateCtx, `second`), nil
 	}))
-	mustSetFlow(d, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/two_consequent_nodes_with_commit.go
+++ b/testcases/two_consequent_nodes_with_commit.go
@@ -7,16 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TwoConsequentNodesWithCommit(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func TwoConsequentNodesWithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	trkr := &Tracker{}
 
-	mustSetFlow(d, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Commit(
 			flowstate.Transit(stateCtx, `second`),
 		), nil
 	}))
-	mustSetFlow(d, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
+	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.End(stateCtx), nil
 	}))

--- a/testcases/watch_labels.go
+++ b/testcases/watch_labels.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func WatchLabels(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func WatchLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/watch_or_labels.go
+++ b/testcases/watch_or_labels.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func WatchORLabels(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func WatchORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	require.NoError(t, e.Do(flowstate.Commit(
 		flowstate.Pause(&flowstate.StateCtx{
 			Current: flowstate.State{

--- a/testcases/watch_since_latest.go
+++ b/testcases/watch_since_latest.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func WatchSinceLatest(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func WatchSinceLatest(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/watch_since_rev.go
+++ b/testcases/watch_since_rev.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func WatchSinceRev(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func WatchSinceRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",

--- a/testcases/watch_since_time.go
+++ b/testcases/watch_since_time.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func WatchSinceTime(t *testing.T, e flowstate.Engine, d flowstate.Driver) {
+func WatchSinceTime(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	stateCtx := &flowstate.StateCtx{
 		Current: flowstate.State{
 			ID: "aTID",


### PR DESCRIPTION
Distributed Flow Execution Support

This PR introduces the foundation for building distributed computing networks using flowstate.

Each node in the network can advertise the flows it owns (see SetFlow). What's particularly elegant is that there's no need for a separate API or service for discovery — advertising is done through the same state commit mechanism. It's recursion all the way down.

Other nodes observe these flow states (see watchFlows) and update their local registries accordingly. When a flow is invoked (see netflow.Flow), the call is routed directly to the node that owns the flow. The coordinator is only used for advertisement (see SetFlow, UnsetFlow, watchFlows), not execution.

This approach allows flows to be dynamically added and removed.

🔍 The most interesting part of the code is here: https://github.com/makasim/flowstate/pull/85/files#diff-eb98dc8149917fa74f4e8f21baa0e3d514ae300b65714f6627e2b09626a8a93fR125

Depends on https://github.com/makasim/flowstate/pull/84