### PR TITLE
Add transition to transit command; add WithAnnotation

### DIFF
--- a/delay.go
+++ b/delay.go
@@ -44,10 +44,10 @@ type DelayCommand struct {
 	DelayingState State
 	ExecuteAt     time.Time
 	Commit        bool
-	To            TransitionID
+	To            FlowID
 }
 
-func (cmd *DelayCommand) WithTransit(to TransitionID) *DelayCommand {
+func (cmd *DelayCommand) WithTransit(to FlowID) *DelayCommand {
 	cmd.To = to
 	return cmd
 }

--- a/delay_synctest_test.go
+++ b/delay_synctest_test.go
@@ -390,7 +390,7 @@ type delayedState struct {
 	At      time.Time
 }
 
-func mustSetFlow(fr flowstate.FlowRegistry, id flowstate.TransitionID, f flowstate.Flow) {
+func mustSetFlow(fr flowstate.FlowRegistry, id flowstate.FlowID, f flowstate.Flow) {
 	if err := fr.SetFlow(id, f); err != nil {
 		panic(fmt.Sprintf("set flow %s: %s", id, err))
 	}

--- a/flow.go
+++ b/flow.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+type FlowID string
+
 type Flow interface {
 	Execute(stateCtx *StateCtx, e Engine) (Command, error)
 }
@@ -16,19 +18,19 @@ func (f FlowFunc) Execute(stateCtx *StateCtx, e Engine) (Command, error) {
 }
 
 type FlowRegistry interface {
-	Flow(id TransitionID) (Flow, error)
-	SetFlow(id TransitionID, flow Flow) error
-	UnsetFlow(id TransitionID) error
+	Flow(id FlowID) (Flow, error)
+	SetFlow(id FlowID, flow Flow) error
+	UnsetFlow(id FlowID) error
 }
 
 var _ FlowRegistry = (*DefaultFlowRegistry)(nil)
 
 type DefaultFlowRegistry struct {
 	mux   sync.Mutex
-	flows map[TransitionID]Flow
+	flows map[FlowID]Flow
 }
 
-func (fr *DefaultFlowRegistry) Flow(id TransitionID) (Flow, error) {
+func (fr *DefaultFlowRegistry) Flow(id FlowID) (Flow, error) {
 	if id == "" {
 		return nil, fmt.Errorf("flow id empty")
 	}
@@ -48,7 +50,7 @@ func (fr *DefaultFlowRegistry) Flow(id TransitionID) (Flow, error) {
 	return f, nil
 }
 
-func (fr *DefaultFlowRegistry) SetFlow(id TransitionID, flow Flow) error {
+func (fr *DefaultFlowRegistry) SetFlow(id FlowID, flow Flow) error {
 	if id == "" {
 		return fmt.Errorf("flow id empty")
 	}
@@ -57,14 +59,14 @@ func (fr *DefaultFlowRegistry) SetFlow(id TransitionID, flow Flow) error {
 	defer fr.mux.Unlock()
 
 	if fr.flows == nil {
-		fr.flows = make(map[TransitionID]Flow)
+		fr.flows = make(map[FlowID]Flow)
 	}
 
 	fr.flows[id] = flow
 	return nil
 }
 
-func (fr *DefaultFlowRegistry) UnsetFlow(id TransitionID) error {
+func (fr *DefaultFlowRegistry) UnsetFlow(id FlowID) error {
 	if id == "" {
 		return fmt.Errorf("flow id empty")
 	}

--- a/netflow/registry.go
+++ b/netflow/registry.go
@@ -43,7 +43,7 @@ func NewRegistry(httpHost string, d flowstate.Driver, l *slog.Logger) *Registry 
 	return fr
 }
 
-func (fr *Registry) Flow(id flowstate.TransitionID) (flowstate.Flow, error) {
+func (fr *Registry) Flow(id flowstate.FlowID) (flowstate.Flow, error) {
 	f, err := fr.fr.Flow(id)
 
 	// slow path, flow not found locally, might not synced yet
@@ -60,7 +60,7 @@ func (fr *Registry) Flow(id flowstate.TransitionID) (flowstate.Flow, error) {
 	return f, nil
 }
 
-func (fr *Registry) SetFlow(id flowstate.TransitionID, flow flowstate.Flow) error {
+func (fr *Registry) SetFlow(id flowstate.FlowID, flow flowstate.Flow) error {
 	if err := fr.fr.SetFlow(id, flow); err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (fr *Registry) SetFlow(id flowstate.TransitionID, flow flowstate.Flow) erro
 	return nil
 }
 
-func (fr *Registry) UnsetFlow(id flowstate.TransitionID) error {
+func (fr *Registry) UnsetFlow(id flowstate.FlowID) error {
 	f0, err := fr.fr.Flow(id)
 	if errors.Is(err, flowstate.ErrNotFound) {
 		return nil
@@ -197,7 +197,7 @@ func (fr *Registry) setFlow(state flowstate.State) {
 		fr.l.Warn("flow state has no 'flowstate.flow.transition_id' annotation set, skipping", "state_id", state.ID, "state_rev", state.Rev)
 		return
 	}
-	tsID := flowstate.TransitionID(state.Annotations[`flowstate.flow.transition_id`])
+	tsID := flowstate.FlowID(state.Annotations[`flowstate.flow.transition_id`])
 
 	if flowstate.Ended(state) {
 		if err := fr.fr.UnsetFlow(tsID); err != nil {
@@ -226,6 +226,6 @@ func (fr *Registry) setFlow(state flowstate.State) {
 	}
 }
 
-func flowStateID(tsID flowstate.TransitionID) flowstate.StateID {
+func flowStateID(tsID flowstate.FlowID) flowstate.StateID {
 	return flowstate.StateID(`flowstate.flow.` + string(tsID))
 }

--- a/proto/flowstate/v1/messages.proto
+++ b/proto/flowstate/v1/messages.proto
@@ -70,6 +70,7 @@ message Command {
 message TransitCommand {
   StateCtxRef state_ref = 1;
   string to = 2;
+  Transition transition = 3;
 }
 
 message PauseCommand {

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -271,6 +271,14 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 			},
 		},
 		To: "theFlowID",
+		Transition: flowstate.Transition{
+			From: "fromFlowID",
+			To:   "toFlowID",
+			Annotations: map[string]string{
+				"fooTsAnnot": "fooVal",
+				"barTsAnnot": "barVal",
+			},
+		},
 	})
 
 	f(&flowstate.PauseCommand{})

--- a/protojson_test.go
+++ b/protojson_test.go
@@ -289,6 +289,14 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 			},
 		},
 		To: "theFlowID",
+		Transition: flowstate.Transition{
+			From: "fromID",
+			To:   "toID",
+			Annotations: map[string]string{
+				"fooTsAnnot": "fooVal",
+				"barTsAnnot": "barVal",
+			},
+		},
 	})
 
 	f(&flowstate.PauseCommand{})

--- a/state.go
+++ b/state.go
@@ -173,12 +173,12 @@ func (s *StateCtx) UnmarshalJSON(data []byte) error {
 	return jsonStateCtx.toStateCtx(s)
 }
 
-type TransitionID string
-
 type Transition struct {
-	From        TransitionID
-	To          TransitionID
+	To          FlowID
 	Annotations map[string]string
+
+	// deprecated
+	From FlowID
 }
 
 func (ts *Transition) SetAnnotation(name, value string) {

--- a/testcases/condition.go
+++ b/testcases/condition.go
@@ -13,7 +13,7 @@ func Condition(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d fl
 	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
-		bID := flowstate.TransitionID(`third`)
+		bID := flowstate.FlowID(`third`)
 		if stateCtx.Current.Annotations["condition"] == "true" {
 			bID = `second`
 		}

--- a/testcases/cron.go
+++ b/testcases/cron.go
@@ -59,7 +59,7 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 				flowstate.Commit(
 					flowstate.Pause(cronStateCtx),
 					flowstate.DelayUntil(cronStateCtx, nextTimes[1]),
-					flowstate.Transit(taskStateCtx, flowstate.TransitionID(taskFlowID)),
+					flowstate.Transit(taskStateCtx, flowstate.FlowID(taskFlowID)),
 				),
 				flowstate.Execute(taskStateCtx),
 			); err != nil {

--- a/testcases/get_one_latest_by_label.go
+++ b/testcases/get_one_latest_by_label.go
@@ -1,7 +1,6 @@
 package testcases
 
 import (
-	"log"
 	"testing"
 
 	"github.com/makasim/flowstate"
@@ -36,8 +35,6 @@ func GetOneLatestByLabel(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegi
 	require.NoError(t, e.Do(flowstate.GetStateByLabels(foundStateCtx, map[string]string{
 		"foo": "fooVal",
 	})))
-	log.Println(stateCtx.Committed.CommittedAt)
-	log.Println(foundStateCtx.Committed.CommittedAt)
 
 	require.Equal(t, stateCtx, foundStateCtx)
 }

--- a/testcases/tracker.go
+++ b/testcases/tracker.go
@@ -89,7 +89,7 @@ func (trkr *Tracker) WaitVisitedEqual(t *testing.T, expVisited []string, wait ti
 	return visited
 }
 
-func mustSetFlow(fr flowstate.FlowRegistry, id flowstate.TransitionID, f flowstate.Flow) {
+func mustSetFlow(fr flowstate.FlowRegistry, id flowstate.FlowID, f flowstate.Flow) {
 	if err := fr.SetFlow(id, f); err != nil {
 		panic(fmt.Sprintf("set flow %s: %s", id, err))
 	}


### PR DESCRIPTION
A preparation PR for the migration from Transit\Pause\Resume\End commands to Transit\Park. 

deprecate `to` in transit command
deprecate `from` in transition