### PR TITLE
Rename end command to park

### DIFF
--- a/delay_synctest_test.go
+++ b/delay_synctest_test.go
@@ -41,7 +41,7 @@ func TestDelayer(t *testing.T) {
 					At:      time.Now().UTC().Truncate(time.Second * 10),
 				})
 
-				return flowstate.Commit(flowstate.End(stateCtx)), nil
+				return flowstate.Commit(flowstate.Park(stateCtx)), nil
 			}))
 
 			e, err := flowstate.NewEngine(d, fr, l)
@@ -256,7 +256,7 @@ func TestDelayer_Concurrency(t *testing.T) {
 				delayedPastCnt.Add(1)
 			}
 
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		}))
 
 		e, err := flowstate.NewEngine(d, fr, l)

--- a/driver.go
+++ b/driver.go
@@ -28,7 +28,7 @@ func DoCommitSubCommand(d Driver, subCmd0 Command) error {
 		return subCmd.Do()
 	case *ResumeCommand:
 		return subCmd.Do()
-	case *EndCommand:
+	case *ParkCommand:
 		return subCmd.Do()
 	case *StackCommand:
 		return subCmd.Do()

--- a/engine.go
+++ b/engine.go
@@ -188,7 +188,7 @@ func (e *engine) doCmd(execSessID int64, cmd0 Command) error {
 		return cmd.Do()
 	case *ResumeCommand:
 		return cmd.Do()
-	case *EndCommand:
+	case *ParkCommand:
 		return cmd.Do()
 	case *NoopCommand:
 		return nil
@@ -312,7 +312,7 @@ func (e *engine) continueExecution(cmd0 Command) (*StateCtx, error) {
 		return nil, nil
 	case *DelayCommand:
 		return nil, nil
-	case *EndCommand:
+	case *ParkCommand:
 		return nil, nil
 	case *NoopCommand:
 		return nil, nil

--- a/examples/delayed_execute/main.go
+++ b/examples/delayed_execute/main.go
@@ -21,7 +21,7 @@ func main() {
 		// Put your business logic here
 
 		// Tell the engine that the state is completed
-		return flowstate.Commit(flowstate.End(stateCtx)), nil
+		return flowstate.Commit(flowstate.Park(stateCtx)), nil
 	}))
 	examples.HandleError(err)
 

--- a/examples/durable_execute/main.go
+++ b/examples/durable_execute/main.go
@@ -20,7 +20,7 @@ func main() {
 		// Put your business logic here
 
 		// Tell the engine that the state is completed
-		return flowstate.Commit(flowstate.End(stateCtx)), nil
+		return flowstate.Commit(flowstate.Park(stateCtx)), nil
 	}))
 	examples.HandleError(err)
 

--- a/examples/execute_with_timeout/main.go
+++ b/examples/execute_with_timeout/main.go
@@ -23,7 +23,7 @@ func main() {
 			slog.Default().Info(fmt.Sprintf("executing timeout logic: %s", stateCtx.Current.ID))
 
 			// Put your timeout handling logic here
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		}
 
 		slog.Default().Info(fmt.Sprintf("executing business logic: %s", stateCtx.Current.ID))
@@ -33,7 +33,7 @@ func main() {
 		time.Sleep(time.Second * time.Duration(8+rand.Intn(6)))
 
 		// Tell the engine that the state is completed
-		return flowstate.Commit(flowstate.End(stateCtx)), nil
+		return flowstate.Commit(flowstate.Park(stateCtx)), nil
 	}))
 	examples.HandleError(err)
 

--- a/examples/queue/main.go
+++ b/examples/queue/main.go
@@ -18,7 +18,7 @@ func main() {
 	err := fr.SetFlow(`example`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
 		slog.Default().Info("Executing state: " + string(stateCtx.Current.ID))
 		// Tell the engine that the state is completed
-		return flowstate.Commit(flowstate.End(stateCtx)), nil
+		return flowstate.Commit(flowstate.Park(stateCtx)), nil
 	}))
 	examples.HandleError(err)
 

--- a/log.go
+++ b/log.go
@@ -78,7 +78,7 @@ func logCommand(msg string, execSessID int64, cmd0 Command, l *slog.Logger) {
 		if len(cmd.StateCtx.Current.Labels) > 0 {
 			args = append(args, "labels", cmd.StateCtx.Current.Labels)
 		}
-	case *EndCommand:
+	case *ParkCommand:
 		args = append(args,
 			"cmd", "end",
 			"id", cmd.StateCtx.Current.ID,

--- a/netdriver/driver.go
+++ b/netdriver/driver.go
@@ -146,10 +146,10 @@ func syncResult(inCmd0, resCmd0 flowstate.Command) error {
 
 		resCmd.StateCtx.CopyTo(inCmd.StateCtx)
 		return nil
-	case *flowstate.EndCommand:
-		resCmd, ok := resCmd0.(*flowstate.EndCommand)
+	case *flowstate.ParkCommand:
+		resCmd, ok := resCmd0.(*flowstate.ParkCommand)
 		if !ok {
-			return fmt.Errorf("resCmd is not a EndCommand")
+			return fmt.Errorf("resCmd is not a ParkCommand")
 		}
 
 		resCmd.StateCtx.CopyTo(inCmd.StateCtx)

--- a/netflow/flow_test.go
+++ b/netflow/flow_test.go
@@ -23,7 +23,7 @@ func TestFlowExecute(t *testing.T) {
 	executedCh := make(chan struct{})
 	if err := fr.SetFlow(`aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, _ flowstate.Engine) (flowstate.Command, error) {
 		close(executedCh)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	})); err != nil {
 		t.Fatalf("failed to set flow: %v", err)
 	}

--- a/netflow/registry.go
+++ b/netflow/registry.go
@@ -123,7 +123,7 @@ func (fr *Registry) UnsetFlow(id flowstate.FlowID) error {
 		return fmt.Errorf("get state by id: %w", err)
 	}
 
-	if err := fr.d.Commit(flowstate.Commit(flowstate.End(stateCtx))); flowstate.IsErrRevMismatch(err) {
+	if err := fr.d.Commit(flowstate.Commit(flowstate.Park(stateCtx))); flowstate.IsErrRevMismatch(err) {
 		// ok
 		return nil
 	} else if err != nil {
@@ -199,7 +199,7 @@ func (fr *Registry) setFlow(state flowstate.State) {
 	}
 	tsID := flowstate.FlowID(state.Annotations[`flowstate.flow.transition_id`])
 
-	if flowstate.Ended(state) {
+	if flowstate.Parked(state) {
 		if err := fr.fr.UnsetFlow(tsID); err != nil {
 			fr.l.Warn("flow registry: unset flow failed", "error", err, "transition_id", tsID, "state_id", state.ID, "state_rev", state.Rev)
 		}

--- a/proto/flowstate/v1/messages.proto
+++ b/proto/flowstate/v1/messages.proto
@@ -51,7 +51,7 @@ message Command {
   TransitCommand transit = 3;
   PauseCommand pause = 4;
   ResumeCommand resume = 5;
-  EndCommand end = 6;
+  ParkCommand park = 6;
   ExecuteCommand execute = 7;
   DelayCommand delay = 8;
   CommitCommand commit = 9;
@@ -68,9 +68,18 @@ message Command {
 }
 
 message TransitCommand {
+  // State to transit, required
   StateCtxRef state_ref = 1;
   string to = 2;
-  Transition transition = 3;
+  // Transition annotations, optional
+  map<string, string> annotations = 3;
+}
+
+message ParkCommand {
+  // State to park, required
+  StateCtxRef state_rexf = 1;
+  // Transition annotations, optional
+  map<string, string> annotations = 3;
 }
 
 message PauseCommand {
@@ -79,11 +88,6 @@ message PauseCommand {
 }
 
 message ResumeCommand {
-  StateCtxRef state_ref = 1;
-  string to = 2;
-}
-
-message EndCommand {
   StateCtxRef state_ref = 1;
   string to = 2;
 }

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -271,13 +271,9 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 			},
 		},
 		To: "theFlowID",
-		Transition: flowstate.Transition{
-			From: "fromFlowID",
-			To:   "toFlowID",
-			Annotations: map[string]string{
-				"fooTsAnnot": "fooVal",
-				"barTsAnnot": "barVal",
-			},
+		Annotations: map[string]string{
+			"fooTsAnnot": "fooVal",
+			"barTsAnnot": "barVal",
 		},
 	})
 
@@ -305,16 +301,19 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 		To: "theFlowID",
 	})
 
-	f(&flowstate.EndCommand{})
+	f(&flowstate.ParkCommand{})
 
-	f(&flowstate.EndCommand{
+	f(&flowstate.ParkCommand{
 		StateCtx: &flowstate.StateCtx{
 			Current: flowstate.State{
 				ID:  "theID",
 				Rev: 123,
 			},
 		},
-		To: "theFlowID",
+		Annotations: map[string]string{
+			"fooTsAnnot": "fooVal",
+			"barTsAnnot": "barVal",
+		},
 	})
 
 	f(&flowstate.ExecuteCommand{})
@@ -643,7 +642,7 @@ func TestMarshalUnmarshalCommandPreserveRef(t *testing.T) {
 		flowstate.Transit(stateCtx, `foo`),
 		flowstate.Pause(stateCtx),
 		flowstate.Resume(stateCtx),
-		flowstate.End(stateCtx),
+		flowstate.Park(stateCtx),
 		flowstate.Stack(stateCtx, stateCtx, `foo`),
 		flowstate.Unstack(stateCtx, stateCtx, `foo`),
 
@@ -677,9 +676,9 @@ func TestMarshalUnmarshalCommandPreserveRef(t *testing.T) {
 		t.Fatalf("expected StateCtx in ResumeCommand to be the same ref stateCtx")
 	}
 
-	actEnd := actCommit.Commands[3].(*flowstate.EndCommand)
-	if actEnd.StateCtx != actStateCtx {
-		t.Fatalf("expected StateCtx in EndCommand to be the same ref stateCtx")
+	actPark := actCommit.Commands[3].(*flowstate.ParkCommand)
+	if actPark.StateCtx != actStateCtx {
+		t.Fatalf("expected StateCtx in ParkCommand to be the same ref stateCtx")
 	}
 
 	actStack := actCommit.Commands[4].(*flowstate.StackCommand)

--- a/protojson_test.go
+++ b/protojson_test.go
@@ -289,13 +289,9 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 			},
 		},
 		To: "theFlowID",
-		Transition: flowstate.Transition{
-			From: "fromID",
-			To:   "toID",
-			Annotations: map[string]string{
-				"fooTsAnnot": "fooVal",
-				"barTsAnnot": "barVal",
-			},
+		Annotations: map[string]string{
+			"fooTsAnnot": "fooVal",
+			"barTsAnnot": "barVal",
 		},
 	})
 
@@ -323,16 +319,19 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 		To: "theFlowID",
 	})
 
-	f(&flowstate.EndCommand{})
+	f(&flowstate.ParkCommand{})
 
-	f(&flowstate.EndCommand{
+	f(&flowstate.ParkCommand{
 		StateCtx: &flowstate.StateCtx{
 			Current: flowstate.State{
 				ID:  "theID",
 				Rev: 123,
 			},
 		},
-		To: "theFlowID",
+		Annotations: map[string]string{
+			"fooTsAnnot": "fooVal",
+			"barTsAnnot": "barVal",
+		},
 	})
 
 	f(&flowstate.ExecuteCommand{})
@@ -661,7 +660,7 @@ func TestMarshalUnmarshalJSONCommandPreserveRef(t *testing.T) {
 		flowstate.Transit(stateCtx, `foo`),
 		flowstate.Pause(stateCtx),
 		flowstate.Resume(stateCtx),
-		flowstate.End(stateCtx),
+		flowstate.Park(stateCtx),
 		flowstate.Stack(stateCtx, stateCtx, `foo`),
 		flowstate.Unstack(stateCtx, stateCtx, `foo`),
 
@@ -698,9 +697,9 @@ func TestMarshalUnmarshalJSONCommandPreserveRef(t *testing.T) {
 		t.Fatalf("expected StateCtx in ResumeCommand to be the same ref stateCtx")
 	}
 
-	actEnd := actCommit.Commands[3].(*flowstate.EndCommand)
-	if actEnd.StateCtx != actStateCtx {
-		t.Fatalf("expected StateCtx in EndCommand to be the same ref stateCtx")
+	actPark := actCommit.Commands[3].(*flowstate.ParkCommand)
+	if actPark.StateCtx != actStateCtx {
+		t.Fatalf("expected StateCtx in ParkCommand to be the same ref stateCtx")
 	}
 
 	actStack := actCommit.Commands[4].(*flowstate.StackCommand)

--- a/recovery.go
+++ b/recovery.go
@@ -305,7 +305,7 @@ func (r *Recoverer) doUpdateHead(dur time.Duration) error {
 			if !r.active {
 				continue
 			}
-			if Ended(state) || Paused(state) {
+			if Parked(state) || Paused(state) {
 				delete(r.states, state.ID)
 				r.completed++
 
@@ -444,7 +444,7 @@ func (r *Recoverer) doRetry() error {
 
 		setRecoveryAttempt(stateCtx, attempt)
 		if attempt > maxAttempts {
-			if err := r.e.Do(Commit(End(stateCtx))); IsErrRevMismatch(err) {
+			if err := r.e.Do(Commit(Park(stateCtx))); IsErrRevMismatch(err) {
 				continue
 			} else if err != nil {
 				return fmt.Errorf("commit state %s:%d reached max retry attempts %d and forcfully ended: %s", state.ID, state.Rev, maxAttempts, err)

--- a/recovery_synctest_test.go
+++ b/recovery_synctest_test.go
@@ -106,7 +106,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			}
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Commited: 1,
@@ -124,7 +124,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 						},
 					}
 
-					if err := e.Do(flowstate.Commit(flowstate.End(stateCtx))); err != nil {
+					if err := e.Do(flowstate.Commit(flowstate.Park(stateCtx))); err != nil {
 						t.Fatalf("failed to commit state %s: %v", stateCtx.Current.ID, err)
 					}
 				}()
@@ -183,7 +183,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			// just commit, do not execute, recovery should kick in
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     2,
@@ -219,7 +219,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			}
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     120,
@@ -308,7 +308,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			}
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     60,
@@ -350,7 +350,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			wg.Wait()
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     1500,
@@ -383,7 +383,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			}
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     10,
@@ -416,7 +416,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			}
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     20,
@@ -451,7 +451,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			}
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     10,
@@ -485,7 +485,7 @@ func TestRecovererRetryLogic(t *testing.T) {
 			}
 		},
 		func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		},
 		flowstate.RecovererStats{
 			Added:     20,
@@ -508,7 +508,7 @@ func TestRecovererActiveStandby(t *testing.T) {
 		d := memdriver.New(l)
 		fr := &flowstate.DefaultFlowRegistry{}
 		mustSetFlow(fr, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		}))
 
 		e, err := flowstate.NewEngine(d, fr, l)
@@ -596,7 +596,7 @@ func TestRecovererCrashStandbyBecomeActive(t *testing.T) {
 		d := memdriver.New(l)
 		fr := &flowstate.DefaultFlowRegistry{}
 		mustSetFlow(fr, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		}))
 
 		e, err := flowstate.NewEngine(d, fr, l)
@@ -693,7 +693,7 @@ func TestRecovererOnlyOneActive(t *testing.T) {
 		d := memdriver.New(l)
 		fr := &flowstate.DefaultFlowRegistry{}
 		mustSetFlow(fr, `aFlow`, flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
-			return flowstate.Commit(flowstate.End(stateCtx)), nil
+			return flowstate.Commit(flowstate.Park(stateCtx)), nil
 		}))
 
 		e, err := flowstate.NewEngine(d, fr, l)

--- a/testcases/call_flow.go
+++ b/testcases/call_flow.go
@@ -57,7 +57,7 @@ func CallFlow(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flo
 				flowstate.Unstack(stateCtx, callStateCtx, `caller_state`),
 				flowstate.Resume(callStateCtx),
 				flowstate.Execute(callStateCtx),
-				flowstate.End(stateCtx),
+				flowstate.Park(stateCtx),
 			); err != nil {
 				return nil, err
 			}
@@ -65,7 +65,7 @@ func CallFlow(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flo
 			return flowstate.Noop(stateCtx), nil
 		}
 
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	mustSetFlow(fr, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
@@ -73,7 +73,7 @@ func CallFlow(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flo
 
 		close(endedCh)
 
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `call`)))

--- a/testcases/call_flow_with_commit.go
+++ b/testcases/call_flow_with_commit.go
@@ -59,7 +59,7 @@ func CallFlowWithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 				flowstate.Commit(
 					flowstate.Unstack(stateCtx, callStateCtx, `caller_state`),
 					flowstate.Resume(callStateCtx),
-					flowstate.End(stateCtx),
+					flowstate.Park(stateCtx),
 				),
 				flowstate.Execute(callStateCtx),
 			); err != nil {
@@ -69,14 +69,14 @@ func CallFlowWithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 			return flowstate.Noop(stateCtx), nil
 		}
 
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 	mustSetFlow(fr, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 
 		close(endedCh)
 
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	stateCtx := &flowstate.StateCtx{

--- a/testcases/call_flow_with_watch.go
+++ b/testcases/call_flow_with_watch.go
@@ -57,7 +57,7 @@ func CallFlowWithWatch(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 			case nextState := <-w.Next():
 				nextStateCtx := nextState.CopyToCtx(&flowstate.StateCtx{})
 
-				if !flowstate.Ended(nextStateCtx.Current) {
+				if !flowstate.Parked(nextStateCtx.Current) {
 					continue
 				}
 
@@ -78,7 +78,7 @@ func CallFlowWithWatch(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 		Track(stateCtx, trkr)
 
 		return flowstate.Commit(
-			flowstate.End(stateCtx),
+			flowstate.Park(stateCtx),
 		), nil
 	}))
 	mustSetFlow(fr, "callEnd", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
@@ -87,7 +87,7 @@ func CallFlowWithWatch(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 		close(endedCh)
 
 		return flowstate.Commit(
-			flowstate.End(stateCtx),
+			flowstate.Park(stateCtx),
 		), nil
 	}))
 

--- a/testcases/condition.go
+++ b/testcases/condition.go
@@ -22,11 +22,11 @@ func Condition(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d fl
 	}))
 	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 	mustSetFlow(fr, "third", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	// condition true

--- a/testcases/cron.go
+++ b/testcases/cron.go
@@ -23,13 +23,13 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 		if err != nil {
 			cronStateCtx.Current.SetAnnotation(`error`, err.Error())
 			return flowstate.Commit(
-				flowstate.End(cronStateCtx),
+				flowstate.Park(cronStateCtx),
 			), nil
 		}
 		if cron.Next(now).IsZero() {
 			cronStateCtx.Current.SetAnnotation(`error`, `next time is zero`)
 			return flowstate.Commit(
-				flowstate.End(cronStateCtx),
+				flowstate.Park(cronStateCtx),
 			), nil
 		}
 
@@ -37,7 +37,7 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 		if taskFlowID == "" {
 			cronStateCtx.Current.SetAnnotation(`error`, `taskFlowID is empty`)
 			return flowstate.Commit(
-				flowstate.End(cronStateCtx),
+				flowstate.Park(cronStateCtx),
 			), nil
 		}
 
@@ -81,7 +81,7 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 	mustSetFlow(fr, "task", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Commit(
-			flowstate.End(stateCtx),
+			flowstate.Park(stateCtx),
 		), nil
 	}))
 

--- a/testcases/data_flow_config.go
+++ b/testcases/data_flow_config.go
@@ -113,7 +113,7 @@ func DataFlowConfig(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry,
 	}))
 	mustSetFlow(fr, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	stateCtx := &flowstate.StateCtx{

--- a/testcases/data_store_get.go
+++ b/testcases/data_store_get.go
@@ -55,7 +55,7 @@ func DataStoreGet(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d
 	}))
 	mustSetFlow(fr, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `store`)))

--- a/testcases/data_store_get_with_commit.go
+++ b/testcases/data_store_get_with_commit.go
@@ -55,7 +55,7 @@ func DataStoreGetWithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowR
 	}))
 	mustSetFlow(fr, "end", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `store`)))

--- a/testcases/delay.go
+++ b/testcases/delay.go
@@ -21,7 +21,7 @@ func Delay(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 	}))
 	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	stateCtx := &flowstate.StateCtx{

--- a/testcases/fork.go
+++ b/testcases/fork.go
@@ -41,11 +41,11 @@ func Fork(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 	}))
 	mustSetFlow(fr, "origin", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 	mustSetFlow(fr, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `fork`)))

--- a/testcases/fork_join_first_wins.go
+++ b/testcases/fork_join_first_wins.go
@@ -80,7 +80,7 @@ func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 				}
 
 				return flowstate.Commit(
-					flowstate.End(stateCtx),
+					flowstate.Park(stateCtx),
 				), nil
 
 			}
@@ -94,7 +94,7 @@ func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 
 	mustSetFlow(fr, "joined", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `fork`)))

--- a/testcases/fork_join_last_wins.go
+++ b/testcases/fork_join_last_wins.go
@@ -82,7 +82,7 @@ func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 				}
 
 				return flowstate.Commit(
-					flowstate.End(stateCtx),
+					flowstate.Park(stateCtx),
 				), nil
 			}
 		}
@@ -95,7 +95,7 @@ func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 
 	mustSetFlow(fr, "joined", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `fork`)))

--- a/testcases/fork_with_commit.go
+++ b/testcases/fork_with_commit.go
@@ -42,12 +42,12 @@ func Fork_WithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry
 	}))
 	mustSetFlow(fr, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	mustSetFlow(fr, "origin", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	require.NoError(t, e.Do(flowstate.Transit(stateCtx, `fork`)))

--- a/testcases/mutex.go
+++ b/testcases/mutex.go
@@ -78,7 +78,7 @@ func Mutex(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 		if err := e.Do(flowstate.Commit(
 			flowstate.Unstack(stateCtx, mutexStateCtx, `mutex_state`),
 			flowstate.Pause(mutexStateCtx).WithTransit(`unlocked`),
-			flowstate.End(stateCtx),
+			flowstate.Park(stateCtx),
 		)); err != nil {
 			return nil, err
 		}

--- a/testcases/queue.go
+++ b/testcases/queue.go
@@ -45,7 +45,7 @@ func Queue(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 				if err := e.Do(
 					flowstate.Commit(
 						flowstate.Resume(queuedStateCtx),
-						flowstate.End(stateCtx),
+						flowstate.Park(stateCtx),
 					),
 					flowstate.Execute(queuedStateCtx),
 				); err != nil {
@@ -59,7 +59,7 @@ func Queue(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 	mustSetFlow(fr, "dequeued", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
 		return flowstate.Commit(
-			flowstate.End(stateCtx),
+			flowstate.Park(stateCtx),
 		), nil
 	}))
 

--- a/testcases/rate_limit.go
+++ b/testcases/rate_limit.go
@@ -59,7 +59,7 @@ func RateLimit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d fl
 
 		if flowstate.Resumed(stateCtx.Current) {
 			return flowstate.Commit(
-				flowstate.End(stateCtx),
+				flowstate.Park(stateCtx),
 			), nil
 		}
 

--- a/testcases/single_node.go
+++ b/testcases/single_node.go
@@ -12,7 +12,7 @@ func SingleNode(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d f
 
 	mustSetFlow(fr, "first", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	stateCtx := &flowstate.StateCtx{

--- a/testcases/three_consequent_nodes.go
+++ b/testcases/three_consequent_nodes.go
@@ -20,7 +20,7 @@ func ThreeConsequentNodes(t *testing.T, e flowstate.Engine, fr flowstate.FlowReg
 	}))
 	mustSetFlow(fr, "third", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	stateCtx := &flowstate.StateCtx{

--- a/testcases/two_consequent_nodes.go
+++ b/testcases/two_consequent_nodes.go
@@ -16,7 +16,7 @@ func TwoConsequentNodes(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 	}))
 	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	stateCtx := &flowstate.StateCtx{

--- a/testcases/two_consequent_nodes_with_commit.go
+++ b/testcases/two_consequent_nodes_with_commit.go
@@ -18,7 +18,7 @@ func TwoConsequentNodesWithCommit(t *testing.T, e flowstate.Engine, fr flowstate
 	}))
 	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
-		return flowstate.End(stateCtx), nil
+		return flowstate.Park(stateCtx), nil
 	}))
 
 	stateCtx := &flowstate.StateCtx{


### PR DESCRIPTION
A preparation PR for the migration from Transit\Pause\Resume\End commands to Transit\Park.

Second one.
First https://github.com/makasim/flowstate/pull/89