### PR TITLE
rework delay command

### DIFF
--- a/badgerdriver/driver.go
+++ b/badgerdriver/driver.go
@@ -213,7 +213,7 @@ func (d *Driver) Delay(cmd *flowstate.DelayCommand) error {
 		}
 
 		delayedState := flowstate.DelayedState{
-			State:     cmd.DelayingState,
+			State:     cmd.Result.State,
 			ExecuteAt: cmd.ExecuteAt,
 			Offset:    nextOffset,
 		}

--- a/delay_synctest_test.go
+++ b/delay_synctest_test.go
@@ -173,9 +173,7 @@ func TestDelayer(t *testing.T) {
 					t.Fatalf("failed to commit state: %v", err)
 				}
 
-				stateCtx.Current.Transition.To = `delayed`
-
-				if err := e.Do(flowstate.Delay(stateCtx, time.Minute*15)); err != nil {
+				if err := e.Do(flowstate.Delay(stateCtx, `delayed`, time.Minute*15)); err != nil {
 					t.Fatalf("failed to delay state: %v", err)
 				}
 			},
@@ -192,7 +190,6 @@ func TestDelayer(t *testing.T) {
 				stateCtx := &flowstate.StateCtx{
 					Current: flowstate.State{ID: `s1`},
 				}
-				stateCtx.Current.Transition.To = `delayed`
 
 				if err := e.Do(flowstate.Commit(flowstate.CommitStateCtx(stateCtx))); err != nil {
 					t.Fatalf("failed to commit state: %v", err)
@@ -203,7 +200,7 @@ func TestDelayer(t *testing.T) {
 					t.Fatalf("failed to commit state: %v", err)
 				}
 
-				if err := e.Do(flowstate.Delay(stateCtx, time.Minute*15)); err != nil {
+				if err := e.Do(flowstate.Delay(stateCtx, `delayed`, time.Minute*15)); err != nil {
 					t.Fatalf("failed to delay state: %v", err)
 				}
 			},
@@ -218,7 +215,6 @@ func TestDelayer(t *testing.T) {
 				stateCtx := &flowstate.StateCtx{
 					Current: flowstate.State{ID: `s1`},
 				}
-				stateCtx.Current.Transition.To = `delayed`
 
 				if err := e.Do(flowstate.Commit(flowstate.CommitStateCtx(stateCtx))); err != nil {
 					t.Fatalf("failed to commit state: %v", err)
@@ -229,7 +225,7 @@ func TestDelayer(t *testing.T) {
 					t.Fatalf("failed to commit state: %v", err)
 				}
 
-				if err := e.Do(flowstate.Delay(stateCtx, time.Minute*15).WithCommit(false)); err != nil {
+				if err := e.Do(flowstate.Delay(stateCtx, `delayed`, time.Minute*15).WithCommit(false)); err != nil {
 					t.Fatalf("failed to delay state: %v", err)
 				}
 			},
@@ -287,13 +283,10 @@ func TestDelayer_Concurrency(t *testing.T) {
 							Labels: map[string]string{
 								`delay`: `future`,
 							},
-							Transition: flowstate.Transition{
-								To: `delayed`,
-							},
 						},
 					}
 
-					if err := e.Do(flowstate.Delay(stateCtx, time.Minute)); err != nil {
+					if err := e.Do(flowstate.Delay(stateCtx, `delayed`, time.Minute)); err != nil {
 						t.Fatalf("failed to delay state: %v", err)
 					}
 
@@ -317,13 +310,10 @@ func TestDelayer_Concurrency(t *testing.T) {
 							Labels: map[string]string{
 								`delay`: `past`,
 							},
-							Transition: flowstate.Transition{
-								To: `delayed`,
-							},
 						},
 					}
 
-					if err := e.Do(flowstate.Delay(stateCtx, -time.Second*10)); err != nil {
+					if err := e.Do(flowstate.Delay(stateCtx, `delayed`, -time.Second*10)); err != nil {
 						t.Fatalf("failed to delay state: %v", err)
 					}
 
@@ -375,11 +365,10 @@ type delayingStateFunc func(t *testing.T, e flowstate.Engine)
 func sleepAndDelay(state flowstate.State, sleepDur, dur time.Duration) delayingStateFunc {
 	return func(t *testing.T, e flowstate.Engine) {
 		stateCtx := state.CopyToCtx(&flowstate.StateCtx{})
-		stateCtx.Current.Transition.To = `delayed`
 
 		time.Sleep(sleepDur)
 
-		if err := e.Do(flowstate.Delay(stateCtx, dur)); err != nil {
+		if err := e.Do(flowstate.Delay(stateCtx, `delayed`, dur)); err != nil {
 			t.Fatalf("failed to delay state: %v", err)
 		}
 	}

--- a/examples/delayed_execute/main.go
+++ b/examples/delayed_execute/main.go
@@ -36,8 +36,7 @@ func main() {
 	// Delay the execution of the state for 1 minute
 	// Delay works like a commit, so it is guaranteed that the state will be executed.
 	err = e.Do(
-		flowstate.Transit(stateCtx, `example`),
-		flowstate.Delay(stateCtx, time.Second*10),
+		flowstate.Delay(stateCtx, `example`, time.Second*10),
 	)
 	examples.HandleError(err)
 

--- a/examples/execute_with_timeout/main.go
+++ b/examples/execute_with_timeout/main.go
@@ -47,8 +47,7 @@ func main() {
 	// Delay works like a commit, so it is guaranteed that the state will be executed.
 	err = e.Do(
 		flowstate.Commit(
-			flowstate.Transit(stateCtx, `example`),
-			flowstate.Delay(stateCtx, time.Second*10),
+			flowstate.Delay(stateCtx, `example`, time.Second*10),
 		),
 		flowstate.Execute(stateCtx),
 	)

--- a/memdriver/driver.go
+++ b/memdriver/driver.go
@@ -144,10 +144,7 @@ func (d *Driver) GetStates(cmd *flowstate.GetStatesCommand) error {
 }
 
 func (d *Driver) Delay(cmd *flowstate.DelayCommand) error {
-	d.delayedStateLog.Append(flowstate.DelayedState{
-		State:     cmd.DelayingState,
-		ExecuteAt: cmd.ExecuteAt,
-	})
+	d.delayedStateLog.Append(*cmd.Result)
 
 	return nil
 }

--- a/netdriver/driver.go
+++ b/netdriver/driver.go
@@ -169,7 +169,7 @@ func syncResult(inCmd0, resCmd0 flowstate.Command) error {
 		}
 
 		resCmd.StateCtx.CopyTo(inCmd.StateCtx)
-		resCmd.DelayingState.CopyTo(&inCmd.DelayingState)
+		resCmd.Result = inCmd.Result
 		return nil
 	case *flowstate.CommitCommand:
 		resCmd, ok := resCmd0.(*flowstate.CommitCommand)

--- a/pgdriver/driver.go
+++ b/pgdriver/driver.go
@@ -110,7 +110,7 @@ func (d *Driver) GetStates(cmd *flowstate.GetStatesCommand) error {
 }
 
 func (d *Driver) Delay(cmd *flowstate.DelayCommand) error {
-	if err := d.q.InsertDelayedState(context.Background(), d.conn, cmd.DelayingState, cmd.ExecuteAt); err != nil {
+	if err := d.q.InsertDelayedState(context.Background(), d.conn, cmd.Result.State, cmd.ExecuteAt); err != nil {
 		return fmt.Errorf("insert delayed state query: %w", err)
 	}
 

--- a/proto/flowstate/v1/messages.proto
+++ b/proto/flowstate/v1/messages.proto
@@ -98,10 +98,14 @@ message ExecuteCommand {
 
 message DelayCommand {
   StateCtxRef state_ref = 1;
-  State delaying_state = 2;
   int64 execute_at_sec = 3;
   bool commit = 4;
   string to = 5;
+  // Transition annotations, optional
+  map<string, string> annotations = 6;
+
+  // Result of successful delay command execution
+  DelayedState result = 2;
 }
 
 message CommitCommand {

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -336,13 +336,21 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 				Rev: 123,
 			},
 		},
-		DelayingState: flowstate.State{
-			ID:  "theDelayingID",
-			Rev: 234,
+		Result: &flowstate.DelayedState{
+			State: flowstate.State{
+				ID:  "theDelayingID",
+				Rev: 234,
+			},
+			Offset:    678,
+			ExecuteAt: time.Unix(345, 0),
 		},
 		ExecuteAt: time.Unix(345, 0),
 		Commit:    true,
 		To:        "theFlowID",
+		Annotations: map[string]string{
+			"fooTsAnnot": "fooVal",
+			"barTsAnnot": "barVal",
+		},
 	})
 
 	f(&flowstate.CommitCommand{})

--- a/protojson_test.go
+++ b/protojson_test.go
@@ -354,13 +354,21 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 				Rev: 123,
 			},
 		},
-		DelayingState: flowstate.State{
-			ID:  "theDelayingID",
-			Rev: 234,
+		Result: &flowstate.DelayedState{
+			State: flowstate.State{
+				ID:  "theDelayingID",
+				Rev: 234,
+			},
+			Offset:    678,
+			ExecuteAt: time.Unix(345, 0),
 		},
 		ExecuteAt: time.Unix(345, 0),
 		Commit:    true,
 		To:        "theFlowID",
+		Annotations: map[string]string{
+			"fooTsAnnot": "fooVal",
+			"barTsAnnot": "barVal",
+		},
 	})
 
 	f(&flowstate.CommitCommand{})

--- a/testcases/cron.go
+++ b/testcases/cron.go
@@ -58,7 +58,7 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 			if err := e.Do(
 				flowstate.Commit(
 					flowstate.Pause(cronStateCtx),
-					flowstate.DelayUntil(cronStateCtx, nextTimes[1]),
+					flowstate.DelayUntil(cronStateCtx, `cron`, nextTimes[1]),
 					flowstate.Transit(taskStateCtx, flowstate.FlowID(taskFlowID)),
 				),
 				flowstate.Execute(taskStateCtx),
@@ -71,7 +71,7 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 
 		if err := e.Do(flowstate.Commit(
 			flowstate.Pause(cronStateCtx),
-			flowstate.DelayUntil(cronStateCtx, nextTimes[0]),
+			flowstate.DelayUntil(cronStateCtx, `cron`, nextTimes[0]),
 		)); err != nil {
 			return nil, err
 		}

--- a/testcases/delay.go
+++ b/testcases/delay.go
@@ -17,7 +17,7 @@ func Delay(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 			return flowstate.Transit(stateCtx, `second`), nil
 		}
 
-		return flowstate.Delay(stateCtx, time.Millisecond*200), nil
+		return flowstate.Delay(stateCtx, `first`, time.Millisecond*200), nil
 	}))
 	mustSetFlow(fr, "second", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)


### PR DESCRIPTION
- require flow id (transition)
- optionally define transition level annotations
- rename delaying stat to result
- change type of result from state to delayed state


A preparation PR for the migration from Transit\Pause\Resume\End commands to Transit\Park.

Second https://github.com/makasim/flowstate/pull/90
First https://github.com/makasim/flowstate/pull/89