### PR TITLE
remove pause command

### DIFF
--- a/delay_synctest_test.go
+++ b/delay_synctest_test.go
@@ -191,12 +191,12 @@ func TestDelayer(t *testing.T) {
 					Current: flowstate.State{ID: `s1`},
 				}
 
-				if err := e.Do(flowstate.Commit(flowstate.CommitStateCtx(stateCtx))); err != nil {
+				if err := e.Do(flowstate.Commit(flowstate.Park(stateCtx))); err != nil {
 					t.Fatalf("failed to commit state: %v", err)
 				}
 
 				stateCtx1 := stateCtx.CopyTo(&flowstate.StateCtx{})
-				if err := e.Do(flowstate.Commit(flowstate.CommitStateCtx(stateCtx1))); err != nil {
+				if err := e.Do(flowstate.Commit(flowstate.Park(stateCtx1))); err != nil {
 					t.Fatalf("failed to commit state: %v", err)
 				}
 
@@ -216,12 +216,12 @@ func TestDelayer(t *testing.T) {
 					Current: flowstate.State{ID: `s1`},
 				}
 
-				if err := e.Do(flowstate.Commit(flowstate.CommitStateCtx(stateCtx))); err != nil {
+				if err := e.Do(flowstate.Commit(flowstate.Park(stateCtx))); err != nil {
 					t.Fatalf("failed to commit state: %v", err)
 				}
 
 				stateCtx1 := stateCtx.CopyTo(&flowstate.StateCtx{})
-				if err := e.Do(flowstate.Commit(flowstate.CommitStateCtx(stateCtx1))); err != nil {
+				if err := e.Do(flowstate.Commit(flowstate.Park(stateCtx1))); err != nil {
 					t.Fatalf("failed to commit state: %v", err)
 				}
 

--- a/driver.go
+++ b/driver.go
@@ -1,6 +1,8 @@
 package flowstate
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Driver interface {
 	// Init must be called by NewEngine only.
@@ -20,13 +22,7 @@ func DoCommitSubCommand(d Driver, subCmd0 Command) error {
 	switch subCmd := subCmd0.(type) {
 	case *NoopCommand:
 		return nil
-	case *CommitStateCtxCommand:
-		return nil
 	case *TransitCommand:
-		return subCmd.Do()
-	case *PauseCommand:
-		return subCmd.Do()
-	case *ResumeCommand:
 		return subCmd.Do()
 	case *ParkCommand:
 		return subCmd.Do()

--- a/engine.go
+++ b/engine.go
@@ -184,10 +184,6 @@ func (e *engine) doCmd(execSessID int64, cmd0 Command) error {
 	switch cmd := cmd0.(type) {
 	case *TransitCommand:
 		return cmd.Do()
-	case *PauseCommand:
-		return cmd.Do()
-	case *ResumeCommand:
-		return cmd.Do()
 	case *ParkCommand:
 		return cmd.Do()
 	case *NoopCommand:
@@ -266,8 +262,6 @@ func (e *engine) doCmd(execSessID int64, cmd0 Command) error {
 		}
 
 		return nil
-	case *CommitStateCtxCommand:
-		return fmt.Errorf("commit state ctx should be passed inside CommitCommand, not as a separate command")
 	case *CommitCommand:
 		if len(cmd.Commands) == 0 {
 			return fmt.Errorf("no commands to commit")
@@ -306,10 +300,6 @@ func (e *engine) continueExecution(cmd0 Command) (*StateCtx, error) {
 		return cmd.StateCtx, nil
 	case *TransitCommand:
 		return cmd.StateCtx, nil
-	case *ResumeCommand:
-		return cmd.StateCtx, nil
-	case *PauseCommand:
-		return nil, nil
 	case *DelayCommand:
 		return nil, nil
 	case *ParkCommand:

--- a/examples/queue/main.go
+++ b/examples/queue/main.go
@@ -37,7 +37,7 @@ func main() {
 		}
 
 		// Queue the states
-		err = e.Do(flowstate.Commit(flowstate.Pause(stateCtx)))
+		err = e.Do(flowstate.Commit(flowstate.Park(stateCtx)))
 		examples.HandleError(err)
 	}
 
@@ -53,7 +53,7 @@ func main() {
 		// you store the progress in another state
 
 		err = e.Do(
-			flowstate.Commit(flowstate.Resume(stateCtx)),
+			flowstate.Commit(flowstate.Transit(stateCtx, `example`)),
 			// Uncomment to execute states in parallel
 			// flowstate.Execute(stateCtx)
 		)

--- a/log.go
+++ b/log.go
@@ -16,10 +16,6 @@ func logExecute(stateCtx *StateCtx, l *slog.Logger) {
 
 	currTs := stateCtx.Current.Transition
 
-	if currTs.Annotations[StateAnnotation] != `` {
-		args = append(args, "state", currTs.Annotations[StateAnnotation])
-	}
-
 	if currTs.Annotations[DelayUntilAnnotation] != `` {
 		args = append(args, "delayed", "true")
 	}
@@ -51,30 +47,9 @@ func logCommand(msg string, execSessID int64, cmd0 Command, l *slog.Logger) {
 			logCommand("commit sub cmd", execSessID, subCmd, l)
 		}
 		return
-	case *CommitStateCtxCommand:
-		args = append(args, "cmd", "commit_state_ctx", "id", cmd.StateCtx.Current.ID, "rev", cmd.StateCtx.Current.Rev)
 	case *TransitCommand:
 		args = append(args, "cmd", "transit", "id", cmd.StateCtx.Current.ID, "rev", cmd.StateCtx.Current.Rev, "to", cmd.To)
 
-		if len(cmd.StateCtx.Current.Labels) > 0 {
-			args = append(args, "labels", cmd.StateCtx.Current.Labels)
-		}
-	case *PauseCommand:
-		args = append(args,
-			"cmd", "pause",
-			"id", cmd.StateCtx.Current.ID,
-			"rev", cmd.StateCtx.Current.Rev,
-		)
-		if cmd.To != `` {
-			args = append(args, "to", cmd.To)
-		}
-		args = append(args, "labels", cmd.StateCtx.Current.Labels)
-	case *ResumeCommand:
-		args = append(args,
-			"cmd", "resume",
-			"id", cmd.StateCtx.Current.ID,
-			"rev", cmd.StateCtx.Current.Rev,
-		)
 		if len(cmd.StateCtx.Current.Labels) > 0 {
 			args = append(args, "labels", cmd.StateCtx.Current.Labels)
 		}
@@ -107,14 +82,7 @@ func logCommand(msg string, execSessID int64, cmd0 Command, l *slog.Logger) {
 			args = append(args, "labels", cmd.StateCtx.Current.Labels)
 		}
 	case *NoopCommand:
-		args = append(args,
-			"cmd", "noop",
-			"id", cmd.StateCtx.Current.ID,
-			"rev", cmd.StateCtx.Current.Rev,
-		)
-		if len(cmd.StateCtx.Current.Labels) > 0 {
-			args = append(args, "labels", cmd.StateCtx.Current.Labels)
-		}
+		args = append(args, "cmd", "noop")
 	case *AttachDataCommand:
 		args = append(args,
 			"cmd", "attach_data",

--- a/netdriver/driver.go
+++ b/netdriver/driver.go
@@ -130,22 +130,6 @@ func syncResult(inCmd0, resCmd0 flowstate.Command) error {
 
 		resCmd.StateCtx.CopyTo(inCmd.StateCtx)
 		return nil
-	case *flowstate.PauseCommand:
-		resCmd, ok := resCmd0.(*flowstate.PauseCommand)
-		if !ok {
-			return fmt.Errorf("resCmd is not a PauseCommand")
-		}
-
-		resCmd.StateCtx.CopyTo(inCmd.StateCtx)
-		return nil
-	case *flowstate.ResumeCommand:
-		resCmd, ok := resCmd0.(*flowstate.ResumeCommand)
-		if !ok {
-			return fmt.Errorf("resCmd is not a ResumeCommand")
-		}
-
-		resCmd.StateCtx.CopyTo(inCmd.StateCtx)
-		return nil
 	case *flowstate.ParkCommand:
 		resCmd, ok := resCmd0.(*flowstate.ParkCommand)
 		if !ok {
@@ -188,12 +172,9 @@ func syncResult(inCmd0, resCmd0 flowstate.Command) error {
 
 		return nil
 	case *flowstate.NoopCommand:
-		resCmd, ok := resCmd0.(*flowstate.ExecuteCommand)
-		if !ok {
-			return fmt.Errorf("resCmd is not a ExecuteCommand")
+		if _, ok := resCmd0.(*flowstate.NoopCommand); !ok {
+			return fmt.Errorf("resCmd is not a NoopCommand")
 		}
-
-		resCmd.StateCtx.CopyTo(inCmd.StateCtx)
 		return nil
 	case *flowstate.StackCommand:
 		resCmd, ok := resCmd0.(*flowstate.StackCommand)
@@ -266,14 +247,6 @@ func syncResult(inCmd0, resCmd0 flowstate.Command) error {
 		}
 
 		inCmd.Result = resCmd.Result
-		return nil
-	case *flowstate.CommitStateCtxCommand:
-		resCmd, ok := resCmd0.(*flowstate.CommitStateCtxCommand)
-		if !ok {
-			return fmt.Errorf("resCmd is not a CommitStateCtxCommand")
-		}
-
-		resCmd.StateCtx.CopyTo(inCmd.StateCtx)
 		return nil
 	default:
 		return fmt.Errorf("unknown inCmd: %T", inCmd0)

--- a/netflow/flow_test.go
+++ b/netflow/flow_test.go
@@ -54,12 +54,8 @@ func TestFlowExecute(t *testing.T) {
 		t.Fatal("expected command, got nil")
 	}
 
-	cmd, ok := cmd0.(*flowstate.NoopCommand)
-	if !ok {
+	if _, ok := cmd0.(*flowstate.NoopCommand); !ok {
 		t.Fatalf("expected NoopCommand, got %T", cmd0)
-	}
-	if cmd.StateCtx.Current.ID != `anID` {
-		t.Fatalf("expected state ID to be 'anID', got '%s'", cmd.StateCtx.Current.ID)
 	}
 
 	select {

--- a/netflow/registry_synctest_test.go
+++ b/netflow/registry_synctest_test.go
@@ -44,7 +44,7 @@ func TestRegistry(t *testing.T) {
 		})); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		
+
 		time.Sleep(time.Second * 7)
 
 		// now we should be able to get all flows
@@ -152,7 +152,7 @@ func TestRegistry_Flow_SlowPath(t *testing.T) {
 		stateCtx.Current.SetLabel(`flow.type`, `remote`)
 		stateCtx.Current.SetAnnotation(`flowstate.flow.transition_id`, `aFlowID`)
 		stateCtx.Current.SetAnnotation(`flowstate.flow.http_host`, `http://anotherHost:8080`)
-		if err := d.Commit(flowstate.Commit(flowstate.Pause(stateCtx))); err != nil {
+		if err := d.Commit(flowstate.Commit(flowstate.Park(stateCtx))); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 

--- a/netflow/server.go
+++ b/netflow/server.go
@@ -36,14 +36,12 @@ func HandleExecute(rw http.ResponseWriter, r *http.Request, e flowstate.Engine) 
 		}
 	}
 
-	resStateCtx := stateCtx.CopyTo(&flowstate.StateCtx{})
-
 	if err := e.Do(flowstate.Execute(stateCtx)); err != nil {
 		writeUnknownError(rw, fmt.Sprintf("failed to execute command: %s", err.Error()), proto)
 		return true
 	}
 
-	writeCmd(rw, flowstate.Noop(resStateCtx), proto)
+	writeCmd(rw, flowstate.Noop(), proto)
 	return true
 }
 

--- a/proto/flowstate/v1/messages.proto
+++ b/proto/flowstate/v1/messages.proto
@@ -49,8 +49,6 @@ message Command {
   repeated Data datas = 2;
 
   TransitCommand transit = 3;
-  PauseCommand pause = 4;
-  ResumeCommand resume = 5;
   ParkCommand park = 6;
   ExecuteCommand execute = 7;
   DelayCommand delay = 8;
@@ -64,7 +62,6 @@ message Command {
   GetStateByLabelsCommand get_state_by_labels = 18;
   GetStatesCommand get_states = 19;
   GetDelayedStatesCommand get_delayed_states = 20;
-  CommitStateCtxCommand commit_state = 21;
 }
 
 message TransitCommand {
@@ -80,16 +77,6 @@ message ParkCommand {
   StateCtxRef state_rexf = 1;
   // Transition annotations, optional
   map<string, string> annotations = 3;
-}
-
-message PauseCommand {
-  StateCtxRef state_ref = 1;
-  string to = 2;
-}
-
-message ResumeCommand {
-  StateCtxRef state_ref = 1;
-  string to = 2;
 }
 
 message ExecuteCommand {
@@ -113,7 +100,6 @@ message CommitCommand {
 }
 
 message NoopCommand {
-  StateCtxRef state_ref = 1;
 }
 
 message StackCommand {
@@ -183,8 +169,4 @@ message GetDelayedStatesCommand {
 message GetDelayedStatesResult {
   repeated DelayedState delayed_states = 1;
   bool more = 2;
-}
-
-message CommitStateCtxCommand {
-  StateCtxRef state_ref = 1;
 }

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -270,30 +270,6 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 		},
 	})
 
-	f(&flowstate.PauseCommand{})
-
-	f(&flowstate.PauseCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-		To: "theFlowID",
-	})
-
-	f(&flowstate.ResumeCommand{})
-
-	f(&flowstate.ResumeCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-		To: "theFlowID",
-	})
-
 	f(&flowstate.ParkCommand{})
 
 	f(&flowstate.ParkCommand{
@@ -359,7 +335,7 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 			&flowstate.TransitCommand{
 				StateCtx: stateCtx,
 			},
-			&flowstate.PauseCommand{
+			&flowstate.ParkCommand{
 				StateCtx: stateCtx,
 			},
 		},
@@ -376,7 +352,7 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 				},
 				To: "theFlowID",
 			},
-			&flowstate.PauseCommand{
+			&flowstate.ParkCommand{
 				StateCtx: &flowstate.StateCtx{
 					Current: flowstate.State{
 						ID:  "thePauseID",
@@ -414,15 +390,6 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 	})
 
 	f(&flowstate.NoopCommand{})
-
-	f(&flowstate.NoopCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-	})
 
 	f(&flowstate.StackCommand{})
 
@@ -618,17 +585,6 @@ func TestMarshalUnmarshalCommand(t *testing.T) {
 			More: true,
 		},
 	})
-
-	f(&flowstate.CommitStateCtxCommand{})
-
-	f(&flowstate.CommitStateCtxCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-	})
 }
 
 func TestMarshalUnmarshalCommandPreserveRef(t *testing.T) {
@@ -641,8 +597,6 @@ func TestMarshalUnmarshalCommandPreserveRef(t *testing.T) {
 
 	exp := flowstate.Commit(
 		flowstate.Transit(stateCtx, `foo`),
-		flowstate.Pause(stateCtx),
-		flowstate.Resume(stateCtx),
 		flowstate.Park(stateCtx),
 		flowstate.Stack(stateCtx, stateCtx, `foo`),
 		flowstate.Unstack(stateCtx, stateCtx, `foo`),
@@ -667,22 +621,12 @@ func TestMarshalUnmarshalCommandPreserveRef(t *testing.T) {
 		t.Fatal("expected non-nil StateCtx in TransitCommand")
 	}
 
-	actPause := actCommit.Commands[1].(*flowstate.PauseCommand)
-	if actPause.StateCtx != actStateCtx {
-		t.Fatalf("expected StateCtx in PauseCommand to be the same ref stateCtx")
-	}
-
-	actResume := actCommit.Commands[2].(*flowstate.ResumeCommand)
-	if actResume.StateCtx != actStateCtx {
-		t.Fatalf("expected StateCtx in ResumeCommand to be the same ref stateCtx")
-	}
-
-	actPark := actCommit.Commands[3].(*flowstate.ParkCommand)
+	actPark := actCommit.Commands[1].(*flowstate.ParkCommand)
 	if actPark.StateCtx != actStateCtx {
 		t.Fatalf("expected StateCtx in ParkCommand to be the same ref stateCtx")
 	}
 
-	actStack := actCommit.Commands[4].(*flowstate.StackCommand)
+	actStack := actCommit.Commands[2].(*flowstate.StackCommand)
 	if actStack.CarrierStateCtx != actStateCtx {
 		t.Fatalf("expected StateCtx in StackCommand to be the same ref stateCtx")
 	}
@@ -690,7 +634,7 @@ func TestMarshalUnmarshalCommandPreserveRef(t *testing.T) {
 		t.Fatalf("expected StateCtx in StackCommand to be the same ref stateCtx")
 	}
 
-	actUnstack := actCommit.Commands[5].(*flowstate.UnstackCommand)
+	actUnstack := actCommit.Commands[3].(*flowstate.UnstackCommand)
 	if actUnstack.CarrierStateCtx != actStateCtx {
 		t.Fatalf("expected StateCtx in UnstackCommand to be the same ref stateCtx")
 	}

--- a/protojson.go
+++ b/protojson.go
@@ -81,30 +81,6 @@ func toJSONCommand(cmd0 Command, stateCtxs stateCtxs, datas datas) (*jsonRootCom
 		}
 
 		jsonRootCmd.Transit = jsonCmd
-	case *PauseCommand:
-		jsonCmd := &jsonGenericCommand{}
-		if cmd.To != "" {
-			jsonCmd.To = &cmd.To
-		}
-		if cmd.StateCtx != nil {
-			jsonCmd.StateRef = &jsonStateCtxRef{
-				Idx: stateCtxs.strIdx(cmd.StateCtx),
-			}
-		}
-
-		jsonRootCmd.Pause = jsonCmd
-	case *ResumeCommand:
-		jsonCmd := &jsonGenericCommand{}
-		if cmd.StateCtx != nil {
-			jsonCmd.StateRef = &jsonStateCtxRef{
-				Idx: stateCtxs.strIdx(cmd.StateCtx),
-			}
-		}
-		if cmd.To != "" {
-			jsonCmd.To = &cmd.To
-		}
-
-		jsonRootCmd.Resume = jsonCmd
 	case *ParkCommand:
 		jsonCmd := &jsonGenericCommand{}
 		if cmd.StateCtx != nil {
@@ -166,14 +142,7 @@ func toJSONCommand(cmd0 Command, stateCtxs stateCtxs, datas datas) (*jsonRootCom
 
 		jsonRootCmd.Commit = commitJsonCmd
 	case *NoopCommand:
-		jsonCmd := &jsonGenericCommand{}
-		if cmd.StateCtx != nil {
-			jsonCmd.StateRef = &jsonStateCtxRef{
-				Idx: stateCtxs.strIdx(cmd.StateCtx),
-			}
-		}
-
-		jsonRootCmd.Noop = jsonCmd
+		jsonRootCmd.Noop = &jsonGenericCommand{}
 	case *StackCommand:
 		jsonCmd := &jsonGenericCommand{}
 		if cmd.CarrierStateCtx != nil {
@@ -337,15 +306,6 @@ func toJSONCommand(cmd0 Command, stateCtxs stateCtxs, datas datas) (*jsonRootCom
 		}
 
 		jsonRootCmd.GetDelayedStates = jsonCmd
-	case *CommitStateCtxCommand:
-		jsonCmd := &jsonGenericCommand{}
-		if cmd.StateCtx != nil {
-			jsonCmd.StateRef = &jsonStateCtxRef{
-				Idx: stateCtxs.strIdx(cmd.StateCtx),
-			}
-		}
-
-		jsonRootCmd.CommitStateCtx = jsonCmd
 	default:
 		return nil, fmt.Errorf("unsupported command %T", cmd0)
 	}
@@ -378,28 +338,6 @@ func unmarshalJSONCommand(jsonRootCmd *jsonRootCommand, stateCtxs stateCtxs, dat
 		}
 		if jsonRootCmd.Transit.Annotations != nil {
 			cmd.Annotations = *jsonRootCmd.Transit.Annotations
-		}
-
-		return cmd, nil
-	case jsonRootCmd.Pause != nil:
-		cmd := &PauseCommand{}
-
-		if jsonRootCmd.Pause.To != nil {
-			cmd.To = *jsonRootCmd.Pause.To
-		}
-		if jsonRootCmd.Pause.StateRef != nil {
-			cmd.StateCtx = stateCtxs.findStrIdx(jsonRootCmd.Pause.StateRef.Idx)
-		}
-
-		return cmd, nil
-	case jsonRootCmd.Resume != nil:
-		cmd := &ResumeCommand{}
-
-		if jsonRootCmd.Resume.StateRef != nil {
-			cmd.StateCtx = stateCtxs.findStrIdx(jsonRootCmd.Resume.StateRef.Idx)
-		}
-		if jsonRootCmd.Resume.To != nil {
-			cmd.To = *jsonRootCmd.Resume.To
 		}
 
 		return cmd, nil
@@ -466,13 +404,7 @@ func unmarshalJSONCommand(jsonRootCmd *jsonRootCommand, stateCtxs stateCtxs, dat
 		}
 		return cmd, nil
 	case jsonRootCmd.Noop != nil:
-		cmd := &NoopCommand{}
-
-		if jsonRootCmd.Noop.StateRef != nil {
-			cmd.StateCtx = stateCtxs.findStrIdx(jsonRootCmd.Noop.StateRef.Idx)
-		}
-
-		return cmd, nil
+		return &NoopCommand{}, nil
 	case jsonRootCmd.Stack != nil:
 		cmd := &StackCommand{}
 
@@ -657,14 +589,6 @@ func unmarshalJSONCommand(jsonRootCmd *jsonRootCommand, stateCtxs stateCtxs, dat
 		}
 
 		return cmd, nil
-	case jsonRootCmd.CommitStateCtx != nil:
-		cmd := &CommitStateCtxCommand{}
-
-		if jsonRootCmd.CommitStateCtx.StateRef != nil {
-			cmd.StateCtx = stateCtxs.findStrIdx(jsonRootCmd.CommitStateCtx.StateRef.Idx)
-		}
-
-		return cmd, nil
 	default:
 		return nil, fmt.Errorf("unsupported command given")
 	}
@@ -683,8 +607,6 @@ type jsonRootCommand struct {
 	Datas     []*Data     `json:"datas,omitempty"`
 
 	Transit          *jsonGenericCommand          `json:"transit,omitempty"`
-	Pause            *jsonGenericCommand          `json:"pause,omitempty"`
-	Resume           *jsonGenericCommand          `json:"resume,omitempty"`
 	Park             *jsonGenericCommand          `json:"park,omitempty"`
 	Execute          *jsonGenericCommand          `json:"execute,omitempty"`
 	Delay            *jsonDelayCommand            `json:"delay,omitempty"`
@@ -698,7 +620,6 @@ type jsonRootCommand struct {
 	GetStateByLabels *jsonGenericCommand          `json:"getStateByLabels,omitempty"`
 	GetStates        *jsonGetStatesCommand        `json:"getStates,omitempty"`
 	GetDelayedStates *jsonGetDelayedStatesCommand `json:"getDelayedStates,omitempty"`
-	CommitStateCtx   *jsonGenericCommand          `json:"commitStateCtx,omitempty"`
 }
 
 type jsonGenericCommand struct {

--- a/protojson_test.go
+++ b/protojson_test.go
@@ -288,30 +288,6 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 		},
 	})
 
-	f(&flowstate.PauseCommand{})
-
-	f(&flowstate.PauseCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-		To: "theFlowID",
-	})
-
-	f(&flowstate.ResumeCommand{})
-
-	f(&flowstate.ResumeCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-		To: "theFlowID",
-	})
-
 	f(&flowstate.ParkCommand{})
 
 	f(&flowstate.ParkCommand{
@@ -377,7 +353,7 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 			&flowstate.TransitCommand{
 				StateCtx: stateCtx,
 			},
-			&flowstate.PauseCommand{
+			&flowstate.ParkCommand{
 				StateCtx: stateCtx,
 			},
 		},
@@ -394,7 +370,7 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 				},
 				To: "theFlowID",
 			},
-			&flowstate.PauseCommand{
+			&flowstate.ParkCommand{
 				StateCtx: &flowstate.StateCtx{
 					Current: flowstate.State{
 						ID:  "thePauseID",
@@ -432,15 +408,6 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 	})
 
 	f(&flowstate.NoopCommand{})
-
-	f(&flowstate.NoopCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-	})
 
 	f(&flowstate.StackCommand{})
 
@@ -636,17 +603,6 @@ func TestMarshalUnmarshalJSONCommand(t *testing.T) {
 			More: true,
 		},
 	})
-
-	f(&flowstate.CommitStateCtxCommand{})
-
-	f(&flowstate.CommitStateCtxCommand{
-		StateCtx: &flowstate.StateCtx{
-			Current: flowstate.State{
-				ID:  "theID",
-				Rev: 123,
-			},
-		},
-	})
 }
 
 func TestMarshalUnmarshalJSONCommandPreserveRef(t *testing.T) {
@@ -659,8 +615,6 @@ func TestMarshalUnmarshalJSONCommandPreserveRef(t *testing.T) {
 
 	exp := flowstate.Commit(
 		flowstate.Transit(stateCtx, `foo`),
-		flowstate.Pause(stateCtx),
-		flowstate.Resume(stateCtx),
 		flowstate.Park(stateCtx),
 		flowstate.Stack(stateCtx, stateCtx, `foo`),
 		flowstate.Unstack(stateCtx, stateCtx, `foo`),
@@ -688,22 +642,12 @@ func TestMarshalUnmarshalJSONCommandPreserveRef(t *testing.T) {
 		t.Fatal("expected non-nil StateCtx in TransitCommand")
 	}
 
-	actPause := actCommit.Commands[1].(*flowstate.PauseCommand)
-	if actPause.StateCtx != actStateCtx {
-		t.Fatalf("expected StateCtx in PauseCommand to be the same ref stateCtx")
-	}
-
-	actResume := actCommit.Commands[2].(*flowstate.ResumeCommand)
-	if actResume.StateCtx != actStateCtx {
-		t.Fatalf("expected StateCtx in ResumeCommand to be the same ref stateCtx")
-	}
-
-	actPark := actCommit.Commands[3].(*flowstate.ParkCommand)
+	actPark := actCommit.Commands[1].(*flowstate.ParkCommand)
 	if actPark.StateCtx != actStateCtx {
 		t.Fatalf("expected StateCtx in ParkCommand to be the same ref stateCtx")
 	}
 
-	actStack := actCommit.Commands[4].(*flowstate.StackCommand)
+	actStack := actCommit.Commands[2].(*flowstate.StackCommand)
 	if actStack.CarrierStateCtx != actStateCtx {
 		t.Fatalf("expected StateCtx in StackCommand to be the same ref stateCtx")
 	}
@@ -711,7 +655,7 @@ func TestMarshalUnmarshalJSONCommandPreserveRef(t *testing.T) {
 		t.Fatalf("expected StateCtx in StackCommand to be the same ref stateCtx")
 	}
 
-	actUnstack := actCommit.Commands[5].(*flowstate.UnstackCommand)
+	actUnstack := actCommit.Commands[3].(*flowstate.UnstackCommand)
 	if actUnstack.CarrierStateCtx != actStateCtx {
 		t.Fatalf("expected StateCtx in UnstackCommand to be the same ref stateCtx")
 	}

--- a/state.go
+++ b/state.go
@@ -21,13 +21,13 @@ type State struct {
 	Transition Transition
 }
 
-//func (s *State) SetCommitedAt(at time.Time) {
-//	s.CommittedAtUnixMilli = at.UnixMilli()
-//}
-//
-//func (s *State) CommittedAt() time.Time {
-//	return time.UnixMilli(s.CommittedAtUnixMilli)
-//}
+func (s State) Annotation(name string) string {
+	if value := s.Transition.Annotations[name]; value != "" {
+		return value
+	}
+
+	return s.Annotations[name]
+}
 
 func (s *State) CopyTo(to *State) State {
 	to.ID = s.ID

--- a/testcases/actor.go
+++ b/testcases/actor.go
@@ -34,7 +34,7 @@ func Actor(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 				}
 			case <-stateCtx.Done():
 				return flowstate.Commit(
-					flowstate.Pause(stateCtx),
+					flowstate.Park(stateCtx),
 				), nil
 			}
 		}
@@ -67,7 +67,7 @@ func Actor(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 
 	require.NoError(t, e.Do(
 		flowstate.Commit(
-			flowstate.Pause(msg0StateCtx).WithTransit(`inbox`),
+			flowstate.Park(msg0StateCtx),
 		),
 	))
 
@@ -82,13 +82,13 @@ func Actor(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowst
 
 	require.NoError(t, e.Do(
 		flowstate.Commit(
-			flowstate.Pause(msg1StateCtx).WithTransit(`inbox`),
+			flowstate.Park(msg1StateCtx),
 		),
 	))
 
 	require.Equal(t, []string{
 		"actor:actorTID",
-		"inbox:msg0TID",
-		"inbox:msg1TID",
-	}, trkr.WaitVisitedEqual(t, []string{`actor:actorTID`, `inbox:msg0TID`, `inbox:msg1TID`}, time.Millisecond*600))
+		":msg0TID",
+		":msg1TID",
+	}, trkr.WaitVisitedEqual(t, []string{`actor:actorTID`, `:msg0TID`, `:msg1TID`}, time.Millisecond*600))
 }

--- a/testcases/call_flow_with_watch.go
+++ b/testcases/call_flow_with_watch.go
@@ -53,7 +53,7 @@ func CallFlowWithWatch(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 		for {
 			select {
 			case <-stateCtx.Done():
-				return flowstate.Noop(stateCtx), nil
+				return flowstate.Noop(), nil
 			case nextState := <-w.Next():
 				nextStateCtx := nextState.CopyToCtx(&flowstate.StateCtx{})
 

--- a/testcases/cron.go
+++ b/testcases/cron.go
@@ -57,7 +57,7 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 
 			if err := e.Do(
 				flowstate.Commit(
-					flowstate.Pause(cronStateCtx),
+					flowstate.Park(cronStateCtx),
 					flowstate.DelayUntil(cronStateCtx, `cron`, nextTimes[1]),
 					flowstate.Transit(taskStateCtx, flowstate.FlowID(taskFlowID)),
 				),
@@ -66,17 +66,17 @@ func Cron(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 				return nil, err
 			}
 
-			return flowstate.Noop(cronStateCtx), nil
+			return flowstate.Noop(), nil
 		}
 
 		if err := e.Do(flowstate.Commit(
-			flowstate.Pause(cronStateCtx),
+			flowstate.Park(cronStateCtx),
 			flowstate.DelayUntil(cronStateCtx, `cron`, nextTimes[0]),
 		)); err != nil {
 			return nil, err
 		}
 
-		return flowstate.Noop(cronStateCtx), nil
+		return flowstate.Noop(), nil
 	}))
 	mustSetFlow(fr, "task", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)

--- a/testcases/fork.go
+++ b/testcases/fork.go
@@ -37,7 +37,7 @@ func Fork(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowsta
 			return nil, err
 		}
 
-		return flowstate.Noop(stateCtx), nil
+		return flowstate.Noop(), nil
 	}))
 	mustSetFlow(fr, "origin", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)

--- a/testcases/fork_join_first_wins.go
+++ b/testcases/fork_join_first_wins.go
@@ -38,7 +38,7 @@ func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 			return nil, err
 		}
 
-		return flowstate.Noop(stateCtx), nil
+		return flowstate.Noop(), nil
 	}))
 	mustSetFlow(fr, "join", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
@@ -60,7 +60,7 @@ func ForkJoin_FirstWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 		for {
 			select {
 			case <-stateCtx.Done():
-				return flowstate.Noop(stateCtx), nil
+				return flowstate.Noop(), nil
 			case changedState := <-w.Next():
 				changedStateCtx := changedState.CopyToCtx(&flowstate.StateCtx{})
 

--- a/testcases/fork_join_last_wins.go
+++ b/testcases/fork_join_last_wins.go
@@ -39,7 +39,7 @@ func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 			return nil, err
 		}
 
-		return flowstate.Noop(stateCtx), nil
+		return flowstate.Noop(), nil
 	}))
 	mustSetFlow(fr, "join", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)
@@ -62,7 +62,7 @@ func ForkJoin_LastWins(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 
 			select {
 			case <-stateCtx.Done():
-				return flowstate.Noop(stateCtx), nil
+				return flowstate.Noop(), nil
 			case changedState := <-w.Next():
 				changedStateCtx := changedState.CopyToCtx(&flowstate.StateCtx{})
 

--- a/testcases/fork_with_commit.go
+++ b/testcases/fork_with_commit.go
@@ -38,7 +38,7 @@ func Fork_WithCommit(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry
 			return nil, err
 		}
 
-		return flowstate.Noop(stateCtx), nil
+		return flowstate.Noop(), nil
 	}))
 	mustSetFlow(fr, "forked", flowstate.FlowFunc(func(stateCtx *flowstate.StateCtx, e flowstate.Engine) (flowstate.Command, error) {
 		Track(stateCtx, trkr)

--- a/testcases/get_many_labels.go
+++ b/testcases/get_many_labels.go
@@ -17,16 +17,16 @@ func GetManyLabels(t *testing.T, e flowstate.Engine, _ flowstate.FlowRegistry, _
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	stateCtx.Current.SetLabel(`bar`, `barVal`)
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(&flowstate.StateCtx{
+		flowstate.Park(&flowstate.StateCtx{
 			Current: flowstate.State{
 				ID: "anotherTID",
 				Labels: map[string]string{
@@ -49,12 +49,10 @@ func GetManyLabels(t *testing.T, e flowstate.Engine, _ flowstate.FlowRegistry, _
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.NotEmpty(t, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[1].ID)
 	require.NotEmpty(t, actStates[1].Rev)
-	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[1].Labels[`foo`])
 	require.Equal(t, `barVal`, actStates[1].Labels[`bar`])
 

--- a/testcases/get_many_latest_only.go
+++ b/testcases/get_many_latest_only.go
@@ -21,10 +21,10 @@ func GetManyLatestOnly(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegist
 
 	for i := 0; i < 3; i++ {
 		require.NoError(t, e.Do(flowstate.Commit(
-			flowstate.Pause(stateCtx),
+			flowstate.Park(stateCtx),
 		)))
 		require.NoError(t, e.Do(flowstate.Commit(
-			flowstate.Pause(stateCtx1),
+			flowstate.Park(stateCtx1),
 		)))
 	}
 

--- a/testcases/get_many_or_labels.go
+++ b/testcases/get_many_or_labels.go
@@ -9,7 +9,7 @@ import (
 
 func GetManyORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(&flowstate.StateCtx{
+		flowstate.Park(&flowstate.StateCtx{
 			Current: flowstate.State{
 				ID: "aTID",
 				Labels: map[string]string{
@@ -20,7 +20,7 @@ func GetManyORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry
 	)))
 
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(&flowstate.StateCtx{
+		flowstate.Park(&flowstate.StateCtx{
 			Current: flowstate.State{
 				ID: "anotherTID",
 				Labels: map[string]string{
@@ -46,13 +46,11 @@ func GetManyORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.NotEmpty(t, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 	require.Equal(t, ``, actStates[0].Labels[`bar`])
 
 	require.Equal(t, flowstate.StateID(`anotherTID`), actStates[1].ID)
 	require.NotEmpty(t, actStates[1].Rev)
-	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, ``, actStates[1].Labels[`foo`])
 	require.Equal(t, `barVal`, actStates[1].Labels[`bar`])
 

--- a/testcases/get_many_since_latest.go
+++ b/testcases/get_many_since_latest.go
@@ -17,13 +17,13 @@ func GetManySinceLatest(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	cmd := flowstate.GetStatesByLabels(map[string]string{
@@ -40,6 +40,5 @@ func GetManySinceLatest(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegis
 	require.Len(t, actStates, 1)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.NotEmpty(t, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 }

--- a/testcases/get_many_since_rev.go
+++ b/testcases/get_many_since_rev.go
@@ -17,15 +17,15 @@ func GetManySinceRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	sinceRev := stateCtx.Committed.Rev
 
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	// filter all since zero revision
@@ -50,12 +50,10 @@ func GetManySinceRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.Greater(t, actStates[0].Rev, sinceRev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[1].ID)
 	require.Greater(t, actStates[1].Rev, sinceRev)
-	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[1].Labels[`foo`])
 
 	require.Greater(t, actStates[1].Rev, actStates[0].Rev)

--- a/testcases/get_many_since_time.go
+++ b/testcases/get_many_since_time.go
@@ -18,7 +18,7 @@ func GetManySinceTime(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistr
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.Greater(t, stateCtx.Committed.CommittedAt.UnixMilli(), int64(0))
 
@@ -44,6 +44,5 @@ func GetManySinceTime(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistr
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.NotEmpty(t, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 }

--- a/testcases/get_one_by_id_and_rev.go
+++ b/testcases/get_one_by_id_and_rev.go
@@ -16,18 +16,19 @@ func GetOneByIDAndRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistr
 
 	stateCtx.Current.SetAnnotation("v", "1")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	expectedStateCtx := stateCtx.CopyTo(&flowstate.StateCtx{})
+	expectedStateCtx.Transitions = nil
 
 	stateCtx.Current.SetAnnotation("v", "2")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	stateCtx.Current.SetAnnotation("v", "3")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	foundStateCtx := &flowstate.StateCtx{}

--- a/testcases/get_one_latest_by_id.go
+++ b/testcases/get_one_latest_by_id.go
@@ -16,17 +16,18 @@ func GetOneLatestByID(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistr
 
 	stateCtx.Current.SetAnnotation("v", "1")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	stateCtx.Current.SetAnnotation("v", "2")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	stateCtx.Current.SetAnnotation("v", "3")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	expStateCtx := stateCtx.CopyTo(&flowstate.StateCtx{})
+	expStateCtx.Transitions = nil
 
 	foundStateCtx := &flowstate.StateCtx{}
 

--- a/testcases/get_one_latest_by_label.go
+++ b/testcases/get_one_latest_by_label.go
@@ -19,16 +19,18 @@ func GetOneLatestByLabel(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegi
 
 	stateCtx.Current.SetAnnotation("v", "1")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	stateCtx.Current.SetAnnotation("v", "2")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	stateCtx.Current.SetAnnotation("v", "3")
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.CommitStateCtx(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
+	expStateCtx := stateCtx.CopyTo(&flowstate.StateCtx{})
+	expStateCtx.Transitions = nil
 
 	foundStateCtx := &flowstate.StateCtx{}
 
@@ -36,5 +38,5 @@ func GetOneLatestByLabel(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegi
 		"foo": "fooVal",
 	})))
 
-	require.Equal(t, stateCtx, foundStateCtx)
+	require.Equal(t, expStateCtx, foundStateCtx)
 }

--- a/testcases/tracker.go
+++ b/testcases/tracker.go
@@ -28,9 +28,9 @@ func Track(stateCtx *flowstate.StateCtx, trkr *Tracker) {
 
 	if trkr.IncludeState {
 		switch {
-		case flowstate.Resumed(stateCtx.Current):
+		case stateCtx.Current.Annotation(`state`) == `resumed`:
 			postfix += `:resumed`
-		case flowstate.Paused(stateCtx.Current):
+		case stateCtx.Current.Annotation(`state`) == `paused`:
 			postfix += `:paused`
 		}
 	}

--- a/testcases/watch_labels.go
+++ b/testcases/watch_labels.go
@@ -19,16 +19,16 @@ func WatchLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d 
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	stateCtx.Current.SetLabel(`bar`, `barVal`)
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(&flowstate.StateCtx{
+		flowstate.Park(&flowstate.StateCtx{
 			Current: flowstate.State{
 				ID: "anotherTID",
 				Labels: map[string]string{
@@ -48,12 +48,10 @@ func WatchLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d 
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.NotEmpty(t, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[1].ID)
 	require.NotEmpty(t, actStates[1].Rev)
-	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[1].Labels[`foo`])
 	require.Equal(t, `barVal`, actStates[1].Labels[`bar`])
 

--- a/testcases/watch_or_labels.go
+++ b/testcases/watch_or_labels.go
@@ -10,7 +10,7 @@ import (
 
 func WatchORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, d flowstate.Driver) {
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(&flowstate.StateCtx{
+		flowstate.Park(&flowstate.StateCtx{
 			Current: flowstate.State{
 				ID: "aTID",
 				Labels: map[string]string{
@@ -21,7 +21,7 @@ func WatchORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, 
 	)))
 
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(&flowstate.StateCtx{
+		flowstate.Park(&flowstate.StateCtx{
 			Current: flowstate.State{
 				ID: "anotherTID",
 				Labels: map[string]string{
@@ -43,13 +43,11 @@ func WatchORLabels(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, 
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.NotEmpty(t, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 	require.Equal(t, ``, actStates[0].Labels[`bar`])
 
 	require.Equal(t, flowstate.StateID(`anotherTID`), actStates[1].ID)
 	require.NotEmpty(t, actStates[1].Rev)
-	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, ``, actStates[1].Labels[`foo`])
 	require.Equal(t, `barVal`, actStates[1].Labels[`bar`])
 

--- a/testcases/watch_since_latest.go
+++ b/testcases/watch_since_latest.go
@@ -18,13 +18,13 @@ func WatchSinceLatest(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistr
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	expRev := stateCtx.Committed.Rev
@@ -39,6 +39,5 @@ func WatchSinceLatest(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistr
 	require.Len(t, actStates, 1)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.Equal(t, expRev, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 }

--- a/testcases/watch_since_rev.go
+++ b/testcases/watch_since_rev.go
@@ -18,15 +18,15 @@ func WatchSinceRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, 
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	sinceRev := stateCtx.Committed.Rev
 
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 
 	w := flowstate.NewWatcher(e, time.Millisecond*100, flowstate.GetStatesByLabels(map[string]string{
@@ -39,12 +39,10 @@ func WatchSinceRev(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry, 
 	require.Len(t, actStates, 2)
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.Greater(t, actStates[0].Rev, sinceRev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[1].ID)
 	require.Greater(t, actStates[1].Rev, sinceRev)
-	require.Equal(t, `paused`, actStates[1].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[1].Labels[`foo`])
 
 	require.Greater(t, actStates[1].Rev, actStates[0].Rev)

--- a/testcases/watch_since_time.go
+++ b/testcases/watch_since_time.go
@@ -18,7 +18,7 @@ func WatchSinceTime(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry,
 		},
 	}
 	require.NoError(t, e.Do(flowstate.Commit(
-		flowstate.Pause(stateCtx),
+		flowstate.Park(stateCtx),
 	)))
 	require.Greater(t, stateCtx.Committed.CommittedAt.UnixMilli(), int64(0))
 
@@ -39,6 +39,5 @@ func WatchSinceTime(t *testing.T, e flowstate.Engine, fr flowstate.FlowRegistry,
 
 	require.Equal(t, flowstate.StateID(`aTID`), actStates[0].ID)
 	require.NotEmpty(t, actStates[0].Rev)
-	require.Equal(t, `paused`, actStates[0].Transition.Annotations[`flowstate.state`])
 	require.Equal(t, `fooVal`, actStates[0].Labels[`foo`])
 }


### PR DESCRIPTION
A final PR for the migration from Transit\Pause\Resume\End commands to Transit\Park where I remove Pause\Resume commands.

Third https://github.com/makasim/flowstate/pull/91
Second https://github.com/makasim/flowstate/pull/90
First https://github.com/makasim/flowstate/pull/89